### PR TITLE
Better initial approximation for Jewish year (

### DIFF
--- a/src/net/sourceforge/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/net/sourceforge/zmanim/hebrewcalendar/JewishDate.java
@@ -801,7 +801,7 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 	 */
 	private void absDateToJewishDate() {
 		// Approximation from below
-		jewishYear = (gregorianAbsDate + JEWISH_EPOCH) / 366;
+		jewishYear = (gregorianAbsDate - JEWISH_EPOCH) / 366;
 		// Search forward for year from the approximation
 		while (gregorianAbsDate >= jewishDateToAbsDate(jewishYear + 1, TISHREI, 1)) {
 			jewishYear++;


### PR DESCRIPTION
When calculating the Jewish year the code starts off with an approximation. That approximation is meant to get it close to the jewish year by taking the absolute date and addin the JEWISH_EPOCH then dividing by 366:

```
private void absDateToJewishDate() {
// Approximation from below
jewishYear = (gregorianAbsDate + JEWISH_EPOCH) / 366;
```

however being that JEWISH_EPOCH is set to 
`private static final int JEWISH_EPOCH = -1373429;`
the approximation ends up 7505 years before the approximate year that it should hit, forcing thousands of unnecessary loops.

this patch fixes it and speeds up the code by about 20x in my testing
