### PR TITLE
Fix ZmanimFormatter.toXML() to return valid XML in all cases

### DIFF
--- a/src/net/sourceforge/zmanim/util/ZmanimFormatter.java
+++ b/src/net/sourceforge/zmanim/util/ZmanimFormatter.java
@@ -476,7 +476,7 @@ public class ZmanimFormatter {
 		} else if (astronomicalCalendar.getClass().getName().equals("net.sourceforge.zmanim.ComplexZmanimCalendar")) {
 			sb.append("</Zmanim>");
 		} else if (astronomicalCalendar.getClass().getName().equals("net.sourceforge.zmanim.ZmanimCalendar")) {
-			sb.append("</Basic>");
+			sb.append("</BasicZmanim>");
 		}
 		return sb.toString();
 	}


### PR DESCRIPTION
For `BasicZmanim`, the closing tag did not match the opening tag. This commit fixes that.