### PR TITLE
Yom Hashoah should be returned where 28 Iyar occurs on Monday

### DIFF
--- a/src/net/sourceforge/zmanim/hebrewcalendar/JewishCalendar.java
+++ b/src/net/sourceforge/zmanim/hebrewcalendar/JewishCalendar.java
@@ -211,7 +211,7 @@ public class JewishCalendar extends JewishDate {
 			}
 			if (isUseModernHolidays()
 					&& ((getJewishDayOfMonth() == 26 && getDayOfWeek() == 5)
-							|| (getJewishDayOfMonth() == 28 && getDayOfWeek() == 1)
+							|| (getJewishDayOfMonth() == 28 && getDayOfWeek() == 2)
 							|| (getJewishDayOfMonth() == 27 && getDayOfWeek() != 1 && getDayOfWeek() != 6))) {
 				return YOM_HASHOAH;
 			}


### PR DESCRIPTION
In the event that 27 Iyar occurs on Sunday, Yom Hashoah would occur on Monday the 28th.  The 28th can actually never fall out on a Sunday.