### PR TITLE
Fix a mistake in Zman.toString()

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/util/Zman.java
+++ b/src/main/java/com/kosherjava/zmanim/util/Zman.java
@@ -239,7 +239,7 @@ public class Zman {
 		sb.append("\nLabel:\t\t\t").append(this.getLabel());
 		sb.append("\nZman:\t\t\t").append(getZman());
 		sb.append("\nDuration:\t\t\t").append(getDuration());
-		sb.append("\nDescription:\t\t\t").append(getDuration());
+		sb.append("\nDescription:\t\t\t").append(getDescription());
 		return sb.toString();
 	}
 }


### PR DESCRIPTION
Caused by f8edfe34e6cb6ccf8a692432a90a0ef37cf2a4f2.