### PR TITLE
Update version and compile against Java 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ This class contains the main functionality of the Zmanim library.
 
 For a basic set of instructions on the use of the API, see [How to Use the Zmanim API](https://kosherjava.com/zmanim-project/how-to-use-the-zmanim-api/), [zmanim code samples](https://kosherjava.com/tag/code-sample/) and the [KosherJava FAQ](https://kosherjava.com/tag/faq/). See the <a href="https://kosherjava.com">KosherJava Zmanim site</a> for additional information.
 
+# Get Started
+To add KosherJava as a dependency to your project, add the following dependency:
+
+#### Maven
+Add the following to your `pom.xml` file:
+```xml
+<dependency>
+  <groupId>com.kosherjava</groupId>
+  <artifactId>zmanim</artifactId>
+  <version>2.0</version>
+</dependency>
+```
+
+#### Gradle
+Add the following to your `build.gradle` file:
+```groovy
+implementation group: 'com.kosherjava', name: 'zmanim', version: '2.01'
+```
+
 License
 -------
 The library is released under the [LGPL 2.1 license](https://kosherjava.com/2011/05/09/kosherjava-zmanim-api-released-under-the-lgpl-license/).

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.kosherjava</groupId>
     <artifactId>zmanim</artifactId>
-    <version>2.0</version>
+    <version>2.01</version>
 
     <name>KosherJava Zmanim</name>
     <description>
@@ -101,8 +101,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>6</source>
+                    <target>6</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/kosherjava/zmanim/util/GeoLocation.java
+++ b/src/main/java/com/kosherjava/zmanim/util/GeoLocation.java
@@ -474,7 +474,7 @@ public class GeoLocation implements Cloneable {
 				/ Math.tan(Math.toRadians(getLatitude()) / 2 + Math.PI / 4));
 		double q = dLat / dPhi;
 
-		if (!Double.isFinite(q)) {
+		if (!(Math.abs(q) <= Double.MAX_VALUE)) {
 			q = Math.cos(Math.toRadians(getLatitude()));
 		}
 		// if dLon over 180° take shorter rhumb across 180° meridian:

--- a/src/main/java/com/kosherjava/zmanim/util/GeoLocationUtils.java
+++ b/src/main/java/com/kosherjava/zmanim/util/GeoLocationUtils.java
@@ -220,7 +220,7 @@ public class GeoLocationUtils {
 				/ Math.tan(Math.toRadians(destination.getLatitude()) / 2 + Math.PI / 4));
 		double q = dLat / dPhi;
 
-		if (!Double.isFinite(q)) {
+		if (!(Math.abs(q) <= Double.MAX_VALUE)) {
 			q = Math.cos(Math.toRadians(destination.getLatitude()));
 		}
 		// if dLon over 180° take shorter rhumb across 180° meridian:


### PR DESCRIPTION
Added "Getting Started" section to readme with dependency info
Removed usage of Java 8 API's in GeoLocation and GeoLocationUtils
Configured `pom.xml` to compile for target version of Java 6