### PR TITLE
Add a constructor and getter for java 8's new date type 'LocalDate'

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
@@ -19,6 +19,7 @@ package com.kosherjava.zmanim.hebrewcalendar;
 
 import com.kosherjava.zmanim.util.GeoLocation;
 
+import java.time.LocalDate;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -155,6 +156,16 @@ public class JewishCalendar extends com.kosherjava.zmanim.hebrewcalendar.JewishD
 	 */
 	public JewishCalendar(Calendar calendar) {
 		super(calendar);
+	}
+
+	/**
+	 * A constructor that initializes the date to the {@link java.time.LocalDate LocalDate} parameter.
+	 * 
+	 * @param localDate
+	 *            the <code>LocalDate</code> to set the calendar to
+	 */
+	public JewishCalendar(LocalDate localDate) {
+		super(localDate);
 	}
 
 	/**

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
@@ -16,6 +16,7 @@
  */
 package com.kosherjava.zmanim.hebrewcalendar;
 
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -992,6 +993,18 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 	}
 
 	/**
+	 * A constructor that initializes the date to the {@link java.time.LocalDate LocalDate} paremeter.
+	 *
+	 * @param localDate
+	 *            the <code>LocalDate</code> to set the calendar to
+	 * @throws IllegalArgumentException
+	 *            if the {@link Calendar#ERA} is {@link GregorianCalendar#BC}
+	 */
+	public JewishDate(LocalDate localDate) {
+		setDate(localDate);
+	}
+
+	/**
 	 * Sets the date based on a {@link java.util.Calendar Calendar} object. Modifies the Jewish date as well.
 	 * 
 	 * @param calendar
@@ -1024,6 +1037,20 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 	public void setDate(Date date) {
 		Calendar cal = Calendar.getInstance();
 		cal.setTime(date);
+		setDate(cal);
+	}
+
+	/**
+	 * Sets the date based on a {@link java.time.LocalDate LocalDate} object. Modifies the Jewish date as well.
+	 *
+	 * @param localDate
+	 *            the <code>LocalDate</code> to set the calendar to
+	 * @throws IllegalArgumentException
+	 *             if the date would fall prior to the year 1 AD
+	 */
+	public void setDate(LocalDate localDate) {
+		Calendar cal = Calendar.getInstance();
+		cal.set(localDate.getYear(), localDate.getMonthValue() - 1, localDate.getDayOfMonth());
 		setDate(cal);
 	}
 
@@ -1151,7 +1178,15 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 		calendar.set(getGregorianYear(), getGregorianMonth(), getGregorianDayOfMonth());
 		return calendar;
 	}
-	
+
+	/**
+	 * Returns this object's date as a {@link java.time.LocalDate} object.
+	 * 
+	 * @return The {@link java.time.LocalDate}
+	 */
+	public LocalDate getLocalDate() {
+		return LocalDate.of(getGregorianYear(), getGregorianMonth() + 1, getGregorianDayOfMonth());
+	}
 
 	/**
 	 * Resets this date to the current system date.


### PR DESCRIPTION
Since java 8 there is very more comfortable object to manage dates, it's call 'localDate'. with this request it's now possible to create a 'jewishDate' and 'jewishCalendar' objects directly from this new object. it's make this project more comfortable to use.