### PR TITLE
fix yerushalmi yomi class

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
@@ -45,12 +45,13 @@ public class YerushalmiYomiCalculator {
 	 * Returns the <a href="https://en.wikipedia.org/wiki/Daf_Yomi">Daf Yomi</a>
 	 * <a href="https://en.wikipedia.org/wiki/Jerusalem_Talmud">Yerusalmi</a> page ({@link Daf}) for a given date.
 	 * The first Daf Yomi cycle started on 15 Shevat (Tu Bishvat), 5740 (February, 2, 1980) and calculations
-	 * prior to this date will result in an IllegalArgumentException thrown.
-	 * 
+	 * prior to this date will result in an IllegalArgumentException thrown. A null will be returned on Tisha B'Av or
+	 * Yom Kippur.
+	 *
 	 * @param calendar
 	 *            the calendar date for calculation
-	 * @return the {@link Daf}.
-	 * 
+	 * @return the {@link Daf} or null if the date is on Tisha B'Av or Yom Kippur.
+	 *
 	 * @throws IllegalArgumentException
 	 *             if the date is prior to the February 2, 1980, the start of the first Daf Yomi Yerushalmi cycle
 	 */
@@ -61,11 +62,11 @@ public class YerushalmiYomiCalculator {
 		Calendar requested = calendar.getGregorianCalendar();
 		int masechta = 0;
 		Daf dafYomi = null;
-		
-		// There isn't Daf Yomi in Yom Kippur and Tisha Beav.
+
+		// There isn't Daf Yomi on Yom Kippur or Tisha B'Av.
 		if ( calendar.getYomTovIndex() == JewishCalendar.YOM_KIPPUR ||
-			 calendar.getYomTovIndex() == JewishCalendar.TISHA_BEAV ) {
-			return new Daf(39,0);
+				calendar.getYomTovIndex() == JewishCalendar.TISHA_BEAV ) {
+			return null;
 		}
 		
 		


### PR DESCRIPTION
So... a little background as to why I want to suggest this fix. I was using the Yerushalmi Calculator in my zmanim app and I noticed that it returned masechta nidda and null for the daf on tisha b'av. Same is true for Yom kippur.

No where in the javadoc does it mention this, only in the code. I had to figure this out the hard way.

In this PR, I suggest a few changes to the javadoc to make it more clear to people to check for edge cases/nulls.

And I don't know why the author decided to return a new Daf(39, 0) instead of just null. That object will return null on the getDaf() method and it is not clear why in the Daf class.

Let me know what you think about this issue.