### PR TITLE
Add single-parameter syntax for com.kosherjava:zmanim dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Add the following to your `pom.xml` file:
 #### Gradle
 Add the following to your `build.gradle` file:
 ```groovy
-implementation group: 'com.kosherjava', name: 'zmanim', version: '2.5.0' // Groovy
+implementation group: 'com.kosherjava', name: 'zmanim', version: '2.5.0'
 ```
+Or if you have `build.gradle.kts` file:
+
 ```kotlin
-implementation("com.kosherjava:zmanim:2.5.0") // Kotlin
+implementation("com.kosherjava:zmanim:2.5.0")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ Add the following to your `pom.xml` file:
 #### Gradle
 Add the following to your `build.gradle` file:
 ```groovy
-implementation group: 'com.kosherjava', name: 'zmanim', version: '2.5.0'
+implementation group: 'com.kosherjava', name: 'zmanim', version: '2.5.0' // Groovy
 ```
+```kotlin
+implementation("com.kosherjava:zmanim:2.5.0") // Kotlin
+```
+
 
 License
 -------


### PR DESCRIPTION
From ChatGPT:
> In the single-parameter syntax, you can directly specify the dependency coordinates as a string enclosed in parentheses. The group, name, and version are separated by colons (":").
> 
> This syntax is supported in Kotlin build scripts, including Gradle Kotlin DSL (.kts) files, where you can use it to simplify dependency declarations.
> 
> Please note that the original code you provided is using Groovy syntax for Gradle build scripts, where the dependency is declared using named arguments. The single-parameter syntax is specific to Kotlin build scripts.

<img width="1354" alt="Screen Shot 2023-06-26 at 15 42 10" src="https://github.com/KosherJava/zmanim/assets/13766004/9bd89a18-841d-426a-95db-632b8970d11c">
