### PR TITLE
add missing MGA methods

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/ComplexZmanimCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/ComplexZmanimCalendar.java
@@ -3820,15 +3820,14 @@ public class ComplexZmanimCalendar extends ZmanimCalendar {
 	 * @see #getSofZmanTfilaMGA72MinutesZmanis()
 	 */
 	public Date getSofZmanAchilasChametzMGA72MinutesZmanis() {
-		/*JewishCalendar jewishCalendar = new JewishCalendar();
+		JewishCalendar jewishCalendar = new JewishCalendar();
 		jewishCalendar.setGregorianDate(getCalendar().get(Calendar.YEAR), getCalendar().get(Calendar.MONTH),
 				getCalendar().get(Calendar.DAY_OF_MONTH));
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
-			return getSofZmanTfilaMGA72Minutes();
+			return getSofZmanTfilaMGA72MinutesZmanis();
 		} else {
 			return null;
-		}*/
-		return getSofZmanTfilaMGA72MinutesZmanis();
+		}
 	}
 
 	/**
@@ -3934,15 +3933,14 @@ public class ComplexZmanimCalendar extends ZmanimCalendar {
 	 * @see #getAlos72Zmanis()
 	 */
 	public Date getSofZmanBiurChametzMGA72MinutesZmanis() {
-		/*JewishCalendar jewishCalendar = new JewishCalendar();
+		JewishCalendar jewishCalendar = new JewishCalendar();
 		jewishCalendar.setGregorianDate(getCalendar().get(Calendar.YEAR), getCalendar().get(Calendar.MONTH),
 				getCalendar().get(Calendar.DAY_OF_MONTH));
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
-			return getTimeOffset(getAlos72(), getShaahZmanisMGA() * 5);
+			return getTimeOffset(getAlos72Zmanis(), getShaahZmanis72MinutesZmanis() * 5);
 		} else {
 			return null;
-		}*/
-		return getTimeOffset(getAlos72Zmanis(), getShaahZmanis72MinutesZmanis() * 5);
+		}
 	}
 
 	/**

--- a/src/main/java/com/kosherjava/zmanim/ComplexZmanimCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/ComplexZmanimCalendar.java
@@ -3802,6 +3802,37 @@ public class ComplexZmanimCalendar extends ZmanimCalendar {
 
 	/**
 	 * This method returns the latest time one is allowed eating <em>chametz</em> on <em>Erev Pesach</em> according to the
+	 * opinion of the <a href="https://en.wikipedia.org/wiki/Avraham_Gombinern">Magen Avraham (MGA)</a> based on <em>alos</em>
+	 * being {@link #getAlos72Zmanis() 72 zmaniyos} minutes before {@link #getSunrise() sunrise}. This time is identical to the
+	 * {@link #getSofZmanTfilaMGA72MinutesZmanis() <em>Sof zman tfilah</em> MGA 72 minutes zmanis}. This time is 4 {@link #getShaahZmanis72MinutesZmanis()
+	 * <em>shaos zmaniyos</em>} (temporal hours) after {@link #getAlos72() dawn} based on the opinion of the MGA that the day is
+	 * calculated from a {@link #getAlos72Zmanis() dawn} of 72 minutes zmanis before sunrise to {@link #getTzais72Zmanis() nightfall} of 72 minutes zmanis
+	 * after sunset. This returns the time of 4 * {@link #getShaahZmanis72MinutesZmanis()} after {@link #getAlos72Zmanis() dawn}. If it is not
+	 * <em>erev Pesach</em>, a null will be returned.
+	 *
+	 * @return the <code>Date</code> of the latest time of eating <em>chametz</em>. If it is not <em>erev Pesach</em> or the
+	 *         calculation can't be computed such as in the Arctic Circle where there is at least one day a year where the sun does
+	 *         not rise, and one where it does not set), a <code>null</code> will be returned. See detailed explanation on top of
+	 *         the {@link AstronomicalCalendar} documentation.
+	 * @todo in v 3.0.0 enable the calendar check for erev pesach and return <code>null</code> in all other cases.
+	 * @see #getShaahZmanis72MinutesZmanis()
+	 * @see #getAlos72Zmanis()
+	 * @see #getSofZmanTfilaMGA72MinutesZmanis()
+	 */
+	public Date getSofZmanAchilasChametzMGA72MinutesZmanis() {
+		/*JewishCalendar jewishCalendar = new JewishCalendar();
+		jewishCalendar.setGregorianDate(getCalendar().get(Calendar.YEAR), getCalendar().get(Calendar.MONTH),
+				getCalendar().get(Calendar.DAY_OF_MONTH));
+		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
+			return getSofZmanTfilaMGA72Minutes();
+		} else {
+			return null;
+		}*/
+		return getSofZmanTfilaMGA72MinutesZmanis();
+	}
+
+	/**
+	 * This method returns the latest time one is allowed eating <em>chametz</em> on <em>Erev Pesach</em> according to the
 	 * opinion of the<a href="https://en.wikipedia.org/wiki/Avraham_Gombinern">Magen Avraham (MGA)</a> based on <em>alos</em>
 	 * being {@link #getAlos16Point1Degrees() 16.1&deg;} before {@link #getSunrise() sunrise}. This time is 4 {@link
 	 * #getShaahZmanis16Point1Degrees() <em>shaos zmaniyos</em>} (solar hours) after {@link #getAlos16Point1Degrees() dawn}
@@ -3883,6 +3914,35 @@ public class ComplexZmanimCalendar extends ZmanimCalendar {
 			return null;
 		}*/
 		return getTimeOffset(getAlos72(), getShaahZmanisMGA() * 5);
+	}
+
+	/**
+	 * FIXME adjust for syncronous
+	 * This method returns the latest time for burning <em>chametz</em> on <em>Erev Pesach</em> according to the opinion of
+	 * the <a href="https://en.wikipedia.org/wiki/Avraham_Gombinern">Magen Avraham (MGA)</a> based on <em>alos</em>
+	 * being {@link #getAlos72Zmanis() 72} minutes zmanis before {@link #getSunrise() sunrise}. This time is 5 {@link
+	 * #getShaahZmanis72MinutesZmanis() <em>shaos zmaniyos</em>} (temporal hours) after {@link #getAlos72Zmanis() dawn} based on the opinion of
+	 * the MGA that the day is calculated from a {@link #getAlos72Zmanis() dawn} of 72 minutes zmanis before sunrise to {@link
+	 * #getTzais72Zmanis() nightfall} of 72 minutes zmanis after sunset. This returns the time of 5 * {@link #getShaahZmanis72MinutesZmanis()} after
+	 * {@link #getAlos72Zmanis() dawn}. If it is not  <em>erev Pesach</em>, a null will be returned.
+	 * @todo in v 3.0.0 enable the calendar check for erev pesach and return <code>null</code> in all other cases.
+	 * @return the <code>Date</code> of the latest time for burning <em>chametz</em> on <em>Erev Pesach</em>. If it is not
+	 *         <em>erev Pesach</em> or the calculation can't be computed such as in the Arctic Circle where there is at
+	 *         least one day a year where the sun does not rise, and one where it does not set), a <code>null</code> will be
+	 *         returned. See detailed explanation on top of the {@link AstronomicalCalendar} documentation.
+	 * @see #getShaahZmanis72MinutesZmanis()
+	 * @see #getAlos72Zmanis()
+	 */
+	public Date getSofZmanBiurChametzMGA72MinutesZmanis() {
+		/*JewishCalendar jewishCalendar = new JewishCalendar();
+		jewishCalendar.setGregorianDate(getCalendar().get(Calendar.YEAR), getCalendar().get(Calendar.MONTH),
+				getCalendar().get(Calendar.DAY_OF_MONTH));
+		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
+			return getTimeOffset(getAlos72(), getShaahZmanisMGA() * 5);
+		} else {
+			return null;
+		}*/
+		return getTimeOffset(getAlos72Zmanis(), getShaahZmanis72MinutesZmanis() * 5);
 	}
 
 	/**


### PR DESCRIPTION
I noticed that these two methods were not included into the API. getSofZmanAchilasChametzMGA72Minutes confused me because I used it thinking it was a zmaniyot/seasonal method. So I added getSofZmanAchilasChametzMGA72MinutesZmanis to cover that case. This calculation is used in the Luach Ohr HaChaim in case you were wondering if someone actually uses it.

I also added getSofZmanBiurChametzMGA72MinutesZmanis for a similar reason. There was no zman covering this case, and I had to implement it myself.