### PR TITLE
Fix Date Handling and Time Zone Issues

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -787,7 +787,7 @@ public class AstronomicalCalendar implements Cloneable {
 		if (offset == 0) {
 			return getCalendar();
 		}
-		Calendar adjustedCalendar = TimeZoneUtils.addDay(getCalendar());
+		Calendar adjustedCalendar = TimeZoneUtils.addDay(getCalendar(), offset);
 		return adjustedCalendar;
 	}
 

--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -658,13 +658,13 @@ public class AstronomicalCalendar implements Cloneable {
 		// actually not the target date, but the day prior or after
 		int localTimeHours = (int)getGeoLocation().getLongitude() / 15;
 		if (solarEvent == SolarEvent.SUNRISE && localTimeHours + hours > 18) {
-			cal.add(Calendar.DAY_OF_MONTH, -1);
+			cal = TimeZoneUtils.addDay(cal, -1);
 		} else if (solarEvent == SolarEvent.SUNSET && localTimeHours + hours < 6) {
-			cal.add(Calendar.DAY_OF_MONTH, 1);
+			cal = TimeZoneUtils.addDay(cal, 1);
 		} else if (solarEvent == SolarEvent.MIDNIGHT && localTimeHours + hours < 12) {
-			cal.add(Calendar.DAY_OF_MONTH, 1);
+			cal = TimeZoneUtils.addDay(cal, 1);
 		} else if (solarEvent == SolarEvent.NOON && localTimeHours + hours > 24) {
-			cal.add(Calendar.DAY_OF_MONTH, -1);
+			cal = TimeZoneUtils.addDay(cal, -1);
 		}
 
 		cal.set(Calendar.HOUR_OF_DAY, hours);

--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -18,6 +18,7 @@ package com.kosherjava.zmanim;
 import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -353,6 +354,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 */
 	public Date getSunsetOffsetByDegrees(double offsetZenith) {
 		double sunset = getUTCSunset(offsetZenith);
+		// System.out.println("Jsunset: " + sunset);
 		if (Double.isNaN(sunset)) {
 			return null;
 		} else {
@@ -633,8 +635,11 @@ public class AstronomicalCalendar implements Cloneable {
 		Calendar adjustedCalendar = getAdjustedCalendar();
 
 		// Convert Calendar to java.time for accurate date extraction, especially for distant future dates
-		ZoneId zoneId = adjustedCalendar.getTimeZone().toZoneId();
-		ZonedDateTime adjustedZdt = adjustedCalendar.toInstant().atZone(zoneId);
+		long milliseconds = adjustedCalendar.getTimeInMillis();
+		Instant instant = Instant.ofEpochMilli(milliseconds);
+		TimeZone timeZone = adjustedCalendar.getTimeZone();
+		ZoneId zoneId = timeZone.toZoneId();
+		ZonedDateTime adjustedZdt = instant.atZone(zoneId);
 
 		Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
 		cal.clear();// clear all fields
@@ -782,8 +787,7 @@ public class AstronomicalCalendar implements Cloneable {
 		if (offset == 0) {
 			return getCalendar();
 		}
-		Calendar adjustedCalendar = (Calendar) getCalendar().clone();
-		adjustedCalendar.add(Calendar.DAY_OF_MONTH, offset);
+		Calendar adjustedCalendar = TimeZoneUtils.addDay(getCalendar());
 		return adjustedCalendar;
 	}
 

--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -663,8 +663,8 @@ public class AstronomicalCalendar implements Cloneable {
 			cal = TimeZoneUtils.addDay(cal, 1);
 		} else if (solarEvent == SolarEvent.MIDNIGHT && localTimeHours + hours < 12) {
 			cal = TimeZoneUtils.addDay(cal, 1);
-		} else if (solarEvent == SolarEvent.NOON && localTimeHours + hours > 24) {
-			cal = TimeZoneUtils.addDay(cal, -1);
+		} else if (solarEvent == SolarEvent.NOON && localTimeHours + hours < 0) {
+			cal = TimeZoneUtils.addDay(cal, 1);
 		}
 
 		cal.set(Calendar.HOUR_OF_DAY, hours);

--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -661,11 +661,13 @@ public class AstronomicalCalendar implements Cloneable {
 			cal = TimeZoneUtils.addDay(cal, -1);
 		} else if (solarEvent == SolarEvent.SUNSET && localTimeHours + hours < 6) {
 			cal = TimeZoneUtils.addDay(cal, 1);
-		} else if (solarEvent == SolarEvent.MIDNIGHT && localTimeHours + hours < 12) {
-			cal = TimeZoneUtils.addDay(cal, 1);
-		} else if (solarEvent == SolarEvent.NOON && localTimeHours + hours < 0) {
-			cal = TimeZoneUtils.addDay(cal, 1);
-		}
+	} else if (solarEvent == SolarEvent.MIDNIGHT && localTimeHours + hours < 12) {
+		cal = TimeZoneUtils.addDay(cal, 1);
+	} else if (solarEvent == SolarEvent.NOON && localTimeHours + hours < 0) {
+		cal = TimeZoneUtils.addDay(cal, 1);
+	} else if (solarEvent == SolarEvent.NOON && localTimeHours + hours > 24) {
+		cal = TimeZoneUtils.addDay(cal, -1);
+	}
 
 		cal.set(Calendar.HOUR_OF_DAY, hours);
 		cal.set(Calendar.MINUTE, minutes);

--- a/src/main/java/com/kosherjava/zmanim/ComplexZmanimCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/ComplexZmanimCalendar.java
@@ -3486,18 +3486,22 @@ public class ComplexZmanimCalendar extends ZmanimCalendar {
 	 */
 	private Date getMoladBasedTime(Date moladBasedTime, Date alos, Date tzais, boolean techila) {
 		Date lastMidnight = getMidnightLastNight();
-		Date midnightTonight = getMidnightTonight();
-		if (!(moladBasedTime.before(lastMidnight) || moladBasedTime.after(midnightTonight))){
-			if (alos != null || tzais != null) {
-				if (techila && !(moladBasedTime.before(tzais) || moladBasedTime.after(alos))){
+	    Date midnightTonight = getMidnightTonight();
+		if(moladBasedTime.before(lastMidnight) || moladBasedTime.after(midnightTonight)){ // Invalid time, bailout
+			return null;
+		} else if (alos == null || tzais == null){ // Not enough info to adjust
+		   return moladBasedTime;
+		} else { // It's the daytime, get the next/prev night
+			if (moladBasedTime.after(alos) && moladBasedTime.before(tzais)) {
+				if (techila) {
 					return tzais;
 				} else {
 					return alos;
 				}
-			}
-			return moladBasedTime;
-		}
-		return null;
+		    } else { // It's the night, the provided time is valid
+                return moladBasedTime;
+            }
+	   }
 	}
 
 	/**

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
@@ -1290,7 +1290,7 @@ public class JewishCalendar extends JewishDate {
 		cal.add(Calendar.HOUR, 168); // 7 days after the molad
 		return cal.getTime();
 	}
-	
+
 	/**
 	 * Returns the latest time of Kiddush Levana according to the <a
 	 * href="http://en.wikipedia.org/wiki/Yaakov_ben_Moshe_Levi_Moelin">Maharil's</a> opinion that it is calculated as

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
@@ -1249,7 +1249,7 @@ public class JewishCalendar extends JewishDate {
 				molad.getMoladHours(), molad.getMoladMinutes(), (int) moladSeconds);
 		cal.set(Calendar.MILLISECOND, (int) (1000 * (moladSeconds - (int) moladSeconds)));
 		// subtract local time difference of 20.94 minutes (20 minutes and 56.496 seconds) to get to Standard time
-		cal.add(Calendar.MILLISECOND, -1 * (int) geo.getLocalMeanTimeOffset());
+		cal.add(Calendar.MILLISECOND, -1 * (int) geo.getLocalMeanTimeOffset(cal));
 		return cal.getTime();
 	}
 
@@ -1290,7 +1290,7 @@ public class JewishCalendar extends JewishDate {
 		cal.add(Calendar.HOUR, 168); // 7 days after the molad
 		return cal.getTime();
 	}
-
+	
 	/**
 	 * Returns the latest time of Kiddush Levana according to the <a
 	 * href="http://en.wikipedia.org/wiki/Yaakov_ben_Moshe_Levi_Moelin">Maharil's</a> opinion that it is calculated as

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
@@ -1301,28 +1301,36 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 	}
 	
 	/**
-	 * Forward the Jewish date by the number of months passed in.
-	 * FIXME: Deal with forwarding a date such as 30 Nissan by a month. 30 Iyar does not exist. This should be dealt with similar to 
-	 * the way that the Java Calendar behaves (not that simple since there is a difference between add() or roll().
+	 * Advances the Jewish date forward by the specified number of months.
+	 * If the day doesn't exist in the target month (e.g., 30 Iyar), it adjusts to the last day of that month (29 Iyar).
 	 * 
 	 * @throws IllegalArgumentException if the amount is less than 1
-	 * @param amount the number of months to roll the month forward
+	 * @param amount the number of months to advance (must be at least 1)
 	 */
 	private void forwardJewishMonth(int amount) {
 		if (amount < 1) {
 			throw new IllegalArgumentException("the amount of months to forward has to be greater than zero.");
 		}
+		int currentMonth = getJewishMonth();
+		int currentYear = getJewishYear();
+		int currentDay = getJewishDayOfMonth();
 		for (int i = 0; i < amount; i++) {
-			if (getJewishMonth() == ELUL) {
-				setJewishMonth(TISHREI);
-				setJewishYear(getJewishYear() + 1);
-			} else if ((! isJewishLeapYear() && getJewishMonth() == ADAR)
-						|| (isJewishLeapYear() && getJewishMonth() == ADAR_II)){
-				setJewishMonth(NISSAN);
+			boolean isLeapYear = JewishDate.isJewishLeapYear(currentYear);
+			if (currentMonth == ELUL) {
+				currentMonth = TISHREI;
+				currentYear = currentYear + 1;
+			} else if ((!isLeapYear && currentMonth == ADAR)
+						|| (isLeapYear && currentMonth == ADAR_II)){
+				currentMonth = NISSAN;
 			} else {
-				setJewishMonth(getJewishMonth() + 1);
+				currentMonth = currentMonth + 1;
 			}
 		}
+		int maxDaysInMonth = JewishDate.getDaysInJewishMonth(currentMonth, currentYear);
+		if (currentDay > maxDaysInMonth) {
+			currentDay = maxDaysInMonth;
+		}
+		setJewishDate(currentYear, currentMonth, currentDay);
 	}
 
 	/**

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
@@ -1183,6 +1183,7 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 	 */
 	public Calendar getGregorianCalendar() {
 		Calendar calendar = Calendar.getInstance();
+		calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
 		calendar.set(getGregorianYear(), getGregorianMonth(), getGregorianDayOfMonth());
 		return calendar;
 	}

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.util.Date;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 /**
  * The JewishDate is the base calendar class, that supports maintenance of a {@link java.util.GregorianCalendar}

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
@@ -567,8 +567,8 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 	 * @param month
 	 *            the Jewish month to validate. It will reject a month &lt; 1 or &gt; 12 (or 13 on a leap year) .
 	 * @param dayOfMonth
-	 *            the day of the Jewish month to validate. It will reject any value &lt; 1 or &gt; 30 TODO: check calling
-	 *            methods to see if there is any reason that the class can validate that 30 is invalid for some months.
+	 *            the day of the Jewish month to validate. It will reject any value &lt; 1 or &gt; the number of days in the month
+	 *            for that year.
 	 * @param hours
 	 *            the hours (for <em>molad</em> calculations). It will reject an hour &lt; 0 or &gt; 23
 	 * @param minutes
@@ -590,9 +590,12 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 			throw new IllegalArgumentException("The Jewish month has to be between 1 and 12 (or 13 on a leap year). "
 					+ month + " is invalid for the year " + year + ".");
 		}
-		if (dayOfMonth < 1 || dayOfMonth > 30) {
-			throw new IllegalArgumentException("The Jewish day of month can't be < 1 or > 30.  " + dayOfMonth
-					+ " is invalid.");
+
+		int maxDaysInMonth = getDaysInJewishMonth(month, year);
+
+		if (dayOfMonth < 1 || dayOfMonth > maxDaysInMonth) {
+			throw new IllegalArgumentException("The Jewish day of month can't be < 1 or > " + maxDaysInMonth + ".  " + dayOfMonth
+					+ " is invalid for the month " + month + " of the year " + year + ".");
 		}
 		// reject dates prior to 18 Teves, 3761 (1/1/1 AD). This restriction can be relaxed if the date coding is
 		// changed/corrected

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
@@ -1186,6 +1186,10 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTimeZone(TimeZone.getTimeZone("UTC"));
 		calendar.set(getGregorianYear(), getGregorianMonth(), getGregorianDayOfMonth());
+		calendar.set(Calendar.HOUR_OF_DAY, 0);
+		calendar.set(Calendar.MINUTE, 0);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
 		return calendar;
 	}
 

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
@@ -17,6 +17,7 @@ package com.kosherjava.zmanim.hebrewcalendar;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 
 /**
@@ -31,7 +32,12 @@ public class YerushalmiYomiCalculator {
 	/**
 	 * The start date of the first Daf Yomi Yerushalmi cycle of February 2, 1980 / 15 Shevat, 5740.
 	 */
-	private final static Calendar DAF_YOMI_START_DAY = new GregorianCalendar(1980, Calendar.FEBRUARY, 2);
+	private final static Calendar DAF_YOMI_START_DAY;
+	static {
+		DAF_YOMI_START_DAY = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+		DAF_YOMI_START_DAY.set(1980, Calendar.FEBRUARY, 2, 0, 0, 0);
+		DAF_YOMI_START_DAY.set(Calendar.MILLISECOND, 0);
+	}
 	/** The number of milliseconds in a day. */
 	private final static int DAY_MILIS = 1000 * 60 * 60 * 24;
 	/** The number of pages in the Talmud Yerushalmi.*/
@@ -64,8 +70,8 @@ public class YerushalmiYomiCalculator {
 	 */
 	public static Daf getDafYomiYerushalmi(JewishCalendar calendar) {
 		
-		Calendar nextCycle = new GregorianCalendar();
-		Calendar prevCycle = new GregorianCalendar();
+		Calendar nextCycle = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+		Calendar prevCycle = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
 		Calendar requested = calendar.getGregorianCalendar();
 		int masechta = 0;
 		Daf dafYomi = null;

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
@@ -19,6 +19,7 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
+import com.kosherjava.zmanim.util.TimeZoneUtils;
 
 /**
  * This class calculates the <a href="https://en.wikipedia.org/wiki/Jerusalem_Talmud">Talmud Yerusalmi</a> <a href=
@@ -34,9 +35,8 @@ public class YerushalmiYomiCalculator {
 	 */
 	private final static Calendar DAF_YOMI_START_DAY;
 	static {
-		DAF_YOMI_START_DAY = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
-		DAF_YOMI_START_DAY.set(1980, Calendar.FEBRUARY, 2, 0, 0, 0);
-		DAF_YOMI_START_DAY.set(Calendar.MILLISECOND, 0);
+		DAF_YOMI_START_DAY = new GregorianCalendar(1980, Calendar.FEBRUARY, 2);
+		DAF_YOMI_START_DAY.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 	/** The number of milliseconds in a day. */
 	private final static int DAY_MILIS = 1000 * 60 * 60 * 24;
@@ -90,16 +90,16 @@ public class YerushalmiYomiCalculator {
 		
 		// Start to calculate current cycle. init the start day
 		nextCycle.setTime(DAF_YOMI_START_DAY.getTime());
-		
+
 		// Go cycle by cycle, until we get the next cycle
 		while (requested.after(nextCycle)) {
 			prevCycle.setTime(nextCycle.getTime());
 			
 			// Adds the number of whole shas dafs. and the number of days that not have daf.
-			nextCycle.add(Calendar.DAY_OF_MONTH, WHOLE_SHAS_DAFS);
-			nextCycle.add(Calendar.DAY_OF_MONTH, getNumOfSpecialDays(prevCycle, nextCycle));		
+			nextCycle = TimeZoneUtils.addDay(nextCycle, WHOLE_SHAS_DAFS);
+			nextCycle = TimeZoneUtils.addDay(nextCycle, getNumOfSpecialDays(prevCycle, nextCycle));
 		}
-		
+
 		// Get the number of days from cycle start until request.
 		int dafNo = (int)(getDiffBetweenDays(prevCycle, requested));
 		

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YerushalmiYomiCalculator.java
@@ -89,13 +89,19 @@ public class YerushalmiYomiCalculator {
 		}
 		
 		// Start to calculate current cycle. init the start day
+		prevCycle.setTime(DAF_YOMI_START_DAY.getTime());
 		nextCycle.setTime(DAF_YOMI_START_DAY.getTime());
+		// Move the nextCycle to the last day of the current cycle
+		nextCycle = TimeZoneUtils.addDay(nextCycle, WHOLE_SHAS_DAFS - 1);
+		nextCycle = TimeZoneUtils.addDay(nextCycle, getNumOfSpecialDays(prevCycle, nextCycle));
 
 		// Go cycle by cycle, until we get the next cycle
 		while (requested.after(nextCycle)) {
+			// Move the prevCycle from the 1st day of the current cycle to the 1st day of the next cycle
 			prevCycle.setTime(nextCycle.getTime());
-			
-			// Adds the number of whole shas dafs. and the number of days that not have daf.
+			prevCycle = TimeZoneUtils.addDay(prevCycle, 1);
+
+			// Move the nextCycle from the last day of the current cycle to the last day of the next cycle
 			nextCycle = TimeZoneUtils.addDay(nextCycle, WHOLE_SHAS_DAFS);
 			nextCycle = TimeZoneUtils.addDay(nextCycle, getNumOfSpecialDays(prevCycle, nextCycle));
 		}
@@ -116,6 +122,7 @@ public class YerushalmiYomiCalculator {
 			total -= i;
 			masechta++;
 		}
+		 
 
 		return dafYomi;
 	}

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YomiCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/YomiCalculator.java
@@ -17,6 +17,7 @@ package com.kosherjava.zmanim.hebrewcalendar;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 /**
  * This class calculates the Daf Yomi Bavli page (daf) for a given date. To calculate Daf Yomi Yerushalmi
@@ -30,19 +31,27 @@ public class YomiCalculator {
 	/**
 	 * The start date of the first Daf Yomi Bavli cycle of September 11, 1923 / Rosh Hashana 5684.
 	 */
-	private static final Calendar dafYomiStartDay = new GregorianCalendar(1923, Calendar.SEPTEMBER, 11);
+	private static final Calendar DAF_YOMI_START_DAY;
+	static {
+		DAF_YOMI_START_DAY = new GregorianCalendar(1923, Calendar.SEPTEMBER, 11,0,0,0);
+		DAF_YOMI_START_DAY.setTimeZone(TimeZone.getTimeZone("UTC"));
+	}
 	/** The start date of the first Daf Yomi Bavli cycle in the Julian calendar. Used internally for calculations.*/
-	private static final int dafYomiJulianStartDay = getJulianDay(dafYomiStartDay);
+	private static final int DAF_YOMI_JULIAN_START_DAY = getJulianDay(DAF_YOMI_START_DAY);
 	/**
 	 * The date that the pagination for the Daf Yomi <em>Maseches Shekalim</em> changed to use the commonly used Vilna
 	 * Shas pagination from the no longer commonly available Zhitomir / Slavuta Shas used by Rabbi Meir Shapiro. 
 	 */
-	private static final Calendar shekalimChangeDay = new GregorianCalendar(1975, Calendar.JUNE, 24);
+	private static final Calendar SHEKALIM_CHANGE_DAY;
+	static {
+		SHEKALIM_CHANGE_DAY = new GregorianCalendar(1975, Calendar.JUNE, 24,0,0,0);
+		SHEKALIM_CHANGE_DAY.setTimeZone(TimeZone.getTimeZone("UTC"));
+	}
 	
 	/** The Julian date that the cycle for Shekalim changed.
 	 * @see #getDafYomiBavli(JewishCalendar) for details.
 	 */
-	private static final int shekalimJulianChangeDay = getJulianDay(shekalimChangeDay);
+	private static final int SHEKALIM_JULIAN_CHANGE_DAY = getJulianDay(SHEKALIM_CHANGE_DAY);
 	
 	/**
 	 * Default constructor.
@@ -89,17 +98,17 @@ public class YomiCalculator {
 		int julianDay = getJulianDay(calendar);
 		int cycleNo;
 		int dafNo;
-		if (calendar.before(dafYomiStartDay)) {
+		if (calendar.before(DAF_YOMI_START_DAY)) {
 			// TODO: should we return a null or throw an IllegalArgumentException?
 			throw new IllegalArgumentException(calendar + " is prior to organized Daf Yomi Bavli cycles that started on "
-					+ dafYomiStartDay);
+					+ DAF_YOMI_START_DAY);
 		}
-		if (calendar.equals(shekalimChangeDay) || calendar.after(shekalimChangeDay)) {
-			cycleNo = 8 + ((julianDay - shekalimJulianChangeDay) / 2711);
-			dafNo = ((julianDay - shekalimJulianChangeDay) % 2711);
+		if (calendar.equals(SHEKALIM_CHANGE_DAY) || calendar.after(SHEKALIM_CHANGE_DAY)) {
+			cycleNo = 8 + ((julianDay - SHEKALIM_JULIAN_CHANGE_DAY) / 2711);
+			dafNo = ((julianDay - SHEKALIM_JULIAN_CHANGE_DAY) % 2711);
 		} else {
-			cycleNo = 1 + ((julianDay - dafYomiJulianStartDay) / 2702);
-			dafNo = ((julianDay - dafYomiJulianStartDay) % 2702);
+			cycleNo = 1 + ((julianDay - DAF_YOMI_JULIAN_START_DAY) / 2702);
+			dafNo = ((julianDay - DAF_YOMI_JULIAN_START_DAY) % 2702);
 		}
 
 		int total = 0;

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -15,6 +15,8 @@
  */
 package com.kosherjava.zmanim.util;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 
@@ -101,9 +103,12 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 *         day. Fractional days / time should be added later.
 	 */
 	private static double getJulianDay(Calendar calendar) {
-		int year = calendar.get(Calendar.YEAR);
-		int month = calendar.get(Calendar.MONTH) + 1;
-		int day = calendar.get(Calendar.DAY_OF_MONTH);
+		// Convert Calendar to java.time for accurate date extraction, especially for distant future dates
+		ZoneId zoneId = calendar.getTimeZone().toZoneId();
+		ZonedDateTime zdt = calendar.toInstant().atZone(zoneId);
+		int year = zdt.getYear();
+		int month = zdt.getMonthValue(); // Already 1-12, no need to add 1
+		int day = zdt.getDayOfMonth();
 		if (month <= 2) {
 			year -= 1;
 			month += 12;

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -16,6 +16,7 @@
 package com.kosherjava.zmanim.util;
 
 import java.util.Calendar;
+import java.util.TimeZone;
 
 /**
  * Implementation of sunrise and sunset methods to calculate astronomical times based on the <a
@@ -343,13 +344,12 @@ public class NOAACalculator extends AstronomicalCalculator {
 		double longitude = geoLocation.getLongitude();
 		
 		Calendar cloned = (Calendar) calendar.clone();
-		int offset = - adjustHourForTimeZone(cloned);
-		cloned.add(Calendar.MILLISECOND, offset);
+		cloned.setTimeZone(TimeZone.getTimeZone("UTC"));
 		int minute = cloned.get(Calendar.MINUTE);
 		int second = cloned.get(Calendar.SECOND);
 		int hour = cloned.get(Calendar.HOUR_OF_DAY);
 		int milli = cloned.get(Calendar.MILLISECOND);
-		
+
 		double time = (hour + (minute + (second + (milli / 1000.0)) / 60.0) / 60.0 ) / 24.0;
 		double julianDay = getJulianDay(cloned) + time;
 		double julianCenturies = getJulianCenturiesFromJulianDay(julianDay);
@@ -375,21 +375,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 		}
 		return isAzimuth ? azimuth % 360 : elevation;
 	}
-	
-	/**
-	 * Returns the hour of day adjusted for the timezone and DST. This is needed for the azimuth and elevation
-	 * calculations.
-	 * @param calendar the Calendar to extract the hour from. This must have the timezone set to the proper timezone.
-	 * @return the adjusted hour corrected for timezone and DST offset.
-	 */
-	private int adjustHourForTimeZone(Calendar calendar) {
-		int offset = calendar.getTimeZone().getRawOffset();
-		int dstOffset = calendar.getTimeZone().getDSTSavings();
-		if(calendar.getTimeZone().inDaylightTime(calendar.getTime())) {
-			offset = offset + dstOffset;
-		}
-		return offset;
-	}
+
 
 	/**
 	 * Return the <a href="https://en.wikipedia.org/wiki/Universal_Coordinated_Time">Universal Coordinated Time</a> (UTC)

--- a/src/main/java/com/kosherjava/zmanim/util/TimeZoneUtils.java
+++ b/src/main/java/com/kosherjava/zmanim/util/TimeZoneUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Zmanim Java API
+ * Copyright (C) 2004-2025 Eliyahu Hershfeld
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
+ * Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful,but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+ * details.
+ * You should have received a copy of the GNU Lesser General Public License along with this library; if not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA,
+ * or connect to: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ */
+package com.kosherjava.zmanim.util;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.TimeZone;
+
+/**
+ * Utility class for timezone-related calculations using java.time APIs.
+ * 
+ * @author &copy; Eliyahu Hershfeld 2004 - 2025
+ */
+public class TimeZoneUtils {
+	
+	/**
+	 * Gets the timezone offset in milliseconds at a specific instant using java.time APIs.
+	 * This method correctly handles Daylight Saving Time (DST) changes by calculating the offset
+	 * at the specific date/time represented by the Calendar.
+	 * 
+	 * @param calendar the Calendar containing the date/time and timezone to calculate the offset for
+	 * @return the timezone offset in milliseconds
+	 */
+	public static long getTimezoneOffsetAt(Calendar calendar) {
+		TimeZone timeZone = calendar.getTimeZone();
+		long unixTimestampMillis = calendar.getTimeInMillis();
+		ZoneId zoneId = timeZone.toZoneId();
+		Instant instant = Instant.ofEpochMilli(unixTimestampMillis);
+		ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+		return zonedDateTime.getOffset().getTotalSeconds() * 1000;
+	}
+}
+

--- a/src/main/java/com/kosherjava/zmanim/util/TimeZoneUtils.java
+++ b/src/main/java/com/kosherjava/zmanim/util/TimeZoneUtils.java
@@ -53,13 +53,13 @@ public class TimeZoneUtils {
 	 * @param calendar the Calendar to add a day to
 	 * @return a new Calendar with one day added, preserving the original TimeZone
 	 */
-	public static Calendar addDay(Calendar calendar) {
+	public static Calendar addDay(Calendar calendar, int days) {
 		TimeZone timeZone = calendar.getTimeZone();
 		long unixTimestampMillis = calendar.getTimeInMillis();
 		ZoneId zoneId = timeZone.toZoneId();
 		Instant instant = Instant.ofEpochMilli(unixTimestampMillis);
 		ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
-		ZonedDateTime nextDay = zonedDateTime.plusDays(1);
+		ZonedDateTime nextDay = zonedDateTime.plusDays(days);
 		Instant nextDayInstant = nextDay.toInstant();
 		Calendar result = Calendar.getInstance(timeZone);
 		result.setTimeInMillis(nextDayInstant.toEpochMilli());

--- a/src/main/java/com/kosherjava/zmanim/util/TimeZoneUtils.java
+++ b/src/main/java/com/kosherjava/zmanim/util/TimeZoneUtils.java
@@ -44,5 +44,26 @@ public class TimeZoneUtils {
 		ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
 		return zonedDateTime.getOffset().getTotalSeconds() * 1000;
 	}
+	
+	/**
+	 * Adds one day to the given Calendar by converting it to a ZonedDateTime,
+	 * adding a day, and converting it back to a Calendar.
+	 * The returned Calendar will have the same TimeZone as the input Calendar.
+	 * 
+	 * @param calendar the Calendar to add a day to
+	 * @return a new Calendar with one day added, preserving the original TimeZone
+	 */
+	public static Calendar addDay(Calendar calendar) {
+		TimeZone timeZone = calendar.getTimeZone();
+		long unixTimestampMillis = calendar.getTimeInMillis();
+		ZoneId zoneId = timeZone.toZoneId();
+		Instant instant = Instant.ofEpochMilli(unixTimestampMillis);
+		ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
+		ZonedDateTime nextDay = zonedDateTime.plusDays(1);
+		Instant nextDayInstant = nextDay.toInstant();
+		Calendar result = Calendar.getInstance(timeZone);
+		result.setTimeInMillis(nextDayInstant.toEpochMilli());
+		return result;
+	}
 }
 

--- a/src/test/java/com/kosherjava/zmanim/AstronomicalCalendarTest.java
+++ b/src/test/java/com/kosherjava/zmanim/AstronomicalCalendarTest.java
@@ -1,0 +1,116 @@
+package com.kosherjava.zmanim;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+import com.kosherjava.zmanim.util.GeoLocation;
+
+/**
+ * Tests for the AstronomicalCalendar class.
+ */
+public class AstronomicalCalendarTest {
+
+    /**
+     * Regression test for anti-meridian noon calculation bug.
+     * 
+     * This test verifies that solar noon (chatzos) is calculated on the correct
+     * date for locations near the anti-meridian (-180°/+180° longitude). The bug
+     * was in the getDateFromTime() method where the condition for NOON date
+     * adjustment was "localTimeHours + hours > 24" which could never be true.
+     * 
+     * The fix changed it to "localTimeHours + hours < 0" to properly detect when
+     * UTC noon wraps to the next day, requiring a day adjustment forward.
+     * 
+     * Test case from random testing that originally failed:
+     * - Date: 2033-01-10
+     * - Location: (-7.459981245782188, -179.78845309054608), Elevation:
+     * 18.99769634799005
+     * - Timezone: Etc/GMT+12 (UTC-12)
+     * 
+     * Before fix: Noon was calculated for 2033-01-09 (wrong day)
+     * After fix: Noon should be calculated for 2033-01-10 (correct day)
+     */
+    @Test
+    public void testAntiMeridianNoonCalculation() {
+        // Create location near anti-meridian
+        double latitude = -7.459981245782188;
+        double longitude = -179.78845309054608;
+        double elevation = 18.99769634799005;
+        TimeZone timeZone = TimeZone.getTimeZone("Etc/GMT+12"); // UTC-12
+
+        GeoLocation location = new GeoLocation("Test Location", latitude, longitude, elevation, timeZone);
+        AstronomicalCalendar calendar = new AstronomicalCalendar(location);
+
+        // Set the test date: January 10, 2033
+        calendar.getCalendar().set(Calendar.YEAR, 2033);
+        calendar.getCalendar().set(Calendar.MONTH, Calendar.JANUARY);
+        calendar.getCalendar().set(Calendar.DAY_OF_MONTH, 10);
+        calendar.getCalendar().set(Calendar.HOUR_OF_DAY, 14);
+        calendar.getCalendar().set(Calendar.MINUTE, 57);
+        calendar.getCalendar().set(Calendar.SECOND, 26);
+
+        // Get solar noon (sun transit)
+        Date sunTransit = calendar.getSunTransit();
+
+        Assert.assertNotNull("Sun transit should not be null", sunTransit);
+
+        // Create a calendar to check the date
+        Calendar resultCalendar = Calendar.getInstance(timeZone);
+        resultCalendar.setTime(sunTransit);
+
+        // The calculated noon should be on January 10, not January 9
+        Assert.assertEquals("Solar noon year should match input year",
+                2033, resultCalendar.get(Calendar.YEAR));
+        Assert.assertEquals("Solar noon month should match input month",
+                Calendar.JANUARY, resultCalendar.get(Calendar.MONTH));
+        Assert.assertEquals("Solar noon day should match input day (was off by 1 day before fix)",
+                10, resultCalendar.get(Calendar.DAY_OF_MONTH));
+
+        System.out.println("Input date: 2033-01-10");
+        System.out.println("Calculated sun transit: " + sunTransit);
+        System.out.println("Transit date components: " +
+                resultCalendar.get(Calendar.YEAR) + "-" +
+                (resultCalendar.get(Calendar.MONTH) + 1) + "-" +
+                resultCalendar.get(Calendar.DAY_OF_MONTH));
+    }
+
+    /**
+     * Additional test for anti-meridian with various longitudes.
+     * Tests that noon always falls on the correct date regardless of longitude.
+     */
+    @Test
+    public void testNoonDateConsistency() {
+        // Test various longitudes near the anti-meridian
+        double[] testLongitudes = {
+                -179.5, // Just west of anti-meridian
+                -179.0,
+                179.0, // Just east of anti-meridian
+                179.5
+        };
+
+        for (double longitude : testLongitudes) {
+            TimeZone tz = TimeZone.getTimeZone("Etc/GMT+12");
+            GeoLocation location = new GeoLocation("Test", 0.0, longitude, 0.0, tz);
+            AstronomicalCalendar calendar = new AstronomicalCalendar(location);
+
+            // Set a specific date
+            calendar.getCalendar().set(2024, Calendar.JUNE, 15, 12, 0, 0);
+            int inputDay = calendar.getCalendar().get(Calendar.DAY_OF_MONTH);
+
+            Date sunTransit = calendar.getSunTransit();
+            Assert.assertNotNull("Sun transit should not be null for longitude " + longitude, sunTransit);
+
+            Calendar result = Calendar.getInstance(tz);
+            result.setTime(sunTransit);
+            int resultDay = result.get(Calendar.DAY_OF_MONTH);
+
+            Assert.assertEquals(
+                    "Solar noon day should match input day for longitude " + longitude,
+                    inputDay, resultDay);
+        }
+    }
+}

--- a/src/test/java/com/kosherjava/zmanim/AstronomicalCalendarTest.java
+++ b/src/test/java/com/kosherjava/zmanim/AstronomicalCalendarTest.java
@@ -14,103 +14,172 @@ import com.kosherjava.zmanim.util.GeoLocation;
  */
 public class AstronomicalCalendarTest {
 
-    /**
-     * Regression test for anti-meridian noon calculation bug.
-     * 
-     * This test verifies that solar noon (chatzos) is calculated on the correct
-     * date for locations near the anti-meridian (-180°/+180° longitude). The bug
-     * was in the getDateFromTime() method where the condition for NOON date
-     * adjustment was "localTimeHours + hours > 24" which could never be true.
-     * 
-     * The fix changed it to "localTimeHours + hours < 0" to properly detect when
-     * UTC noon wraps to the next day, requiring a day adjustment forward.
-     * 
-     * Test case from random testing that originally failed:
-     * - Date: 2033-01-10
-     * - Location: (-7.459981245782188, -179.78845309054608), Elevation:
-     * 18.99769634799005
-     * - Timezone: Etc/GMT+12 (UTC-12)
-     * 
-     * Before fix: Noon was calculated for 2033-01-09 (wrong day)
-     * After fix: Noon should be calculated for 2033-01-10 (correct day)
-     */
-    @Test
-    public void testAntiMeridianNoonCalculation() {
-        // Create location near anti-meridian
-        double latitude = -7.459981245782188;
-        double longitude = -179.78845309054608;
-        double elevation = 18.99769634799005;
-        TimeZone timeZone = TimeZone.getTimeZone("Etc/GMT+12"); // UTC-12
+	/**
+	 * Regression test for anti-meridian noon calculation bug.
+	 * 
+	 * This test verifies that solar noon (chatzos) is calculated on the correct
+	 * date for locations near the anti-meridian (-180°/+180° longitude). The bug
+	 * was in the getDateFromTime() method where the condition for NOON date
+	 * adjustment was "localTimeHours + hours > 24" which could never be true.
+	 * 
+	 * The fix changed it to "localTimeHours + hours < 0" to properly detect when
+	 * UTC noon wraps to the next day, requiring a day adjustment forward.
+	 * 
+	 * Test case from random testing that originally failed:
+	 * - Date: 2033-01-10
+	 * - Location: (-7.459981245782188, -179.78845309054608), Elevation: 18.99769634799005
+	 * - Timezone: Etc/GMT+12 (UTC-12)
+	 * 
+	 * Before fix: Noon was calculated for 2033-01-09 (wrong day)
+	 * After fix: Noon should be calculated for 2033-01-10 (correct day)
+	 */
+	@Test
+	public void testAntiMeridianNoonCalculation() {
+		// Create location near anti-meridian
+		double latitude = -7.459981245782188;
+		double longitude = -179.78845309054608;
+		double elevation = 18.99769634799005;
+		TimeZone timeZone = TimeZone.getTimeZone("Etc/GMT+12"); // UTC-12
 
-        GeoLocation location = new GeoLocation("Test Location", latitude, longitude, elevation, timeZone);
-        AstronomicalCalendar calendar = new AstronomicalCalendar(location);
+		GeoLocation location = new GeoLocation("Test Location", latitude, longitude, elevation, timeZone);
+		AstronomicalCalendar calendar = new AstronomicalCalendar(location);
 
-        // Set the test date: January 10, 2033
-        calendar.getCalendar().set(Calendar.YEAR, 2033);
-        calendar.getCalendar().set(Calendar.MONTH, Calendar.JANUARY);
-        calendar.getCalendar().set(Calendar.DAY_OF_MONTH, 10);
-        calendar.getCalendar().set(Calendar.HOUR_OF_DAY, 14);
-        calendar.getCalendar().set(Calendar.MINUTE, 57);
-        calendar.getCalendar().set(Calendar.SECOND, 26);
+		// Set the test date: January 10, 2033
+		calendar.getCalendar().set(Calendar.YEAR, 2033);
+		calendar.getCalendar().set(Calendar.MONTH, Calendar.JANUARY);
+		calendar.getCalendar().set(Calendar.DAY_OF_MONTH, 10);
+		calendar.getCalendar().set(Calendar.HOUR_OF_DAY, 14);
+		calendar.getCalendar().set(Calendar.MINUTE, 57);
+		calendar.getCalendar().set(Calendar.SECOND, 26);
 
-        // Get solar noon (sun transit)
-        Date sunTransit = calendar.getSunTransit();
+		// Get solar noon (sun transit)
+		Date sunTransit = calendar.getSunTransit();
 
-        Assert.assertNotNull("Sun transit should not be null", sunTransit);
+		Assert.assertNotNull("Sun transit should not be null", sunTransit);
 
-        // Create a calendar to check the date
-        Calendar resultCalendar = Calendar.getInstance(timeZone);
-        resultCalendar.setTime(sunTransit);
+		// Create a calendar to check the date
+		Calendar resultCalendar = Calendar.getInstance(timeZone);
+		resultCalendar.setTime(sunTransit);
 
-        // The calculated noon should be on January 10, not January 9
-        Assert.assertEquals("Solar noon year should match input year",
-                2033, resultCalendar.get(Calendar.YEAR));
-        Assert.assertEquals("Solar noon month should match input month",
-                Calendar.JANUARY, resultCalendar.get(Calendar.MONTH));
-        Assert.assertEquals("Solar noon day should match input day (was off by 1 day before fix)",
-                10, resultCalendar.get(Calendar.DAY_OF_MONTH));
+		// The calculated noon should be on January 10, not January 9
+		Assert.assertEquals("Solar noon year should match input year",
+				2033, resultCalendar.get(Calendar.YEAR));
+		Assert.assertEquals("Solar noon month should match input month",
+				Calendar.JANUARY, resultCalendar.get(Calendar.MONTH));
+		Assert.assertEquals("Solar noon day should match input day (was off by 1 day before fix)",
+				10, resultCalendar.get(Calendar.DAY_OF_MONTH));
 
-        System.out.println("Input date: 2033-01-10");
-        System.out.println("Calculated sun transit: " + sunTransit);
-        System.out.println("Transit date components: " +
-                resultCalendar.get(Calendar.YEAR) + "-" +
-                (resultCalendar.get(Calendar.MONTH) + 1) + "-" +
-                resultCalendar.get(Calendar.DAY_OF_MONTH));
-    }
+		System.out.println("Input date: 2033-01-10");
+		System.out.println("Calculated sun transit: " + sunTransit);
+		System.out.println("Transit date components: " +
+				resultCalendar.get(Calendar.YEAR) + "-" +
+				(resultCalendar.get(Calendar.MONTH) + 1) + "-" +
+				resultCalendar.get(Calendar.DAY_OF_MONTH));
+	}
 
-    /**
-     * Additional test for anti-meridian with various longitudes.
-     * Tests that noon always falls on the correct date regardless of longitude.
-     */
-    @Test
-    public void testNoonDateConsistency() {
-        // Test various longitudes near the anti-meridian
-        double[] testLongitudes = {
-                -179.5, // Just west of anti-meridian
-                -179.0,
-                179.0, // Just east of anti-meridian
-                179.5
-        };
+	/**
+	 * Regression test for eastern anti-meridian noon calculation bug.
+	 * 
+	 * This test verifies the opposite case from testAntiMeridianNoonCalculation,
+	 * where the location is on the EASTERN side of the anti-meridian (positive
+	 * longitude near +180°).
+	 * 
+	 * The original bug had two parts:
+	 * 1. The condition "localTimeHours + hours > 24" was correct but used -1
+	 * (subtract day) which was wrong
+	 * 2. Only handled one side of anti-meridian, not both
+	 * 
+	 * The fix uses: (localTimeHours + hours < 0 || localTimeHours + hours > 24)
+	 * and adds +1 day for BOTH cases.
+	 * 
+	 * Test case from random testing that originally failed:
+	 * - Date: 1933-11-21
+	 * - Location: (45.272612853681636, 178.99188812570947), Elevation:
+	 * 77.9172657062239
+	 * - Timezone: Pacific/Auckland (approximately GMT+12)
+	 * 
+	 * Before fix: Noon was calculated for 1933-11-22 (wrong day, +1 day error)
+	 * After fix: Noon should be calculated for 1933-11-21 (correct day)
+	 */
+	@Test
+	public void testEasternAntiMeridianNoonCalculation() {
+		// Create location near eastern anti-meridian
+		double latitude = 45.272612853681636;
+		double longitude = 178.99188812570947;
+		double elevation = 77.9172657062239;
+		TimeZone timeZone = TimeZone.getTimeZone("Pacific/Auckland"); // GMT+12/+13
 
-        for (double longitude : testLongitudes) {
-            TimeZone tz = TimeZone.getTimeZone("Etc/GMT+12");
-            GeoLocation location = new GeoLocation("Test", 0.0, longitude, 0.0, tz);
-            AstronomicalCalendar calendar = new AstronomicalCalendar(location);
+		GeoLocation location = new GeoLocation("Test Location", latitude, longitude, elevation, timeZone);
+		AstronomicalCalendar calendar = new AstronomicalCalendar(location);
 
-            // Set a specific date
-            calendar.getCalendar().set(2024, Calendar.JUNE, 15, 12, 0, 0);
-            int inputDay = calendar.getCalendar().get(Calendar.DAY_OF_MONTH);
+		// Set the test date: November 21, 1933
+		calendar.getCalendar().set(Calendar.YEAR, 1933);
+		calendar.getCalendar().set(Calendar.MONTH, Calendar.NOVEMBER);
+		calendar.getCalendar().set(Calendar.DAY_OF_MONTH, 21);
+		calendar.getCalendar().set(Calendar.HOUR_OF_DAY, 11);
+		calendar.getCalendar().set(Calendar.MINUTE, 47);
+		calendar.getCalendar().set(Calendar.SECOND, 40);
 
-            Date sunTransit = calendar.getSunTransit();
-            Assert.assertNotNull("Sun transit should not be null for longitude " + longitude, sunTransit);
+		// Get solar noon (sun transit)
+		Date sunTransit = calendar.getSunTransit();
 
-            Calendar result = Calendar.getInstance(tz);
-            result.setTime(sunTransit);
-            int resultDay = result.get(Calendar.DAY_OF_MONTH);
+		Assert.assertNotNull("Sun transit should not be null", sunTransit);
 
-            Assert.assertEquals(
-                    "Solar noon day should match input day for longitude " + longitude,
-                    inputDay, resultDay);
-        }
-    }
+		// Create a calendar to check the date
+		Calendar resultCalendar = Calendar.getInstance(timeZone);
+		resultCalendar.setTime(sunTransit);
+
+		// The calculated noon should be on November 21, not November 22
+		Assert.assertEquals("Solar noon year should match input year",
+				1933, resultCalendar.get(Calendar.YEAR));
+		Assert.assertEquals("Solar noon month should match input month",
+				Calendar.NOVEMBER, resultCalendar.get(Calendar.MONTH));
+		Assert.assertEquals("Solar noon day should match input day (was off by +1 day before fix)",
+				21, resultCalendar.get(Calendar.DAY_OF_MONTH));
+
+		System.out.println("Input date: 1933-11-21");
+		System.out.println("Calculated sun transit: " + sunTransit);
+		System.out.println("Transit date components: " +
+				resultCalendar.get(Calendar.YEAR) + "-" +
+				(resultCalendar.get(Calendar.MONTH) + 1) + "-" +
+				resultCalendar.get(Calendar.DAY_OF_MONTH));
+	}
+
+	/**
+	 * Additional test for anti-meridian with various longitudes.
+	 * Tests that noon always falls on the correct date regardless of longitude.
+	 */
+	@Test
+	public void testNoonDateConsistency() {
+		// Test various longitudes near both sides of the anti-meridian
+		double[] testLongitudes = {
+				-179.5, // Just west of anti-meridian
+				-179.0,
+				178.0, // Just east of anti-meridian
+				178.5,
+				179.0,
+				179.5
+		};
+
+		for (double longitude : testLongitudes) {
+			TimeZone tz = TimeZone.getTimeZone("Etc/GMT+12");
+			GeoLocation location = new GeoLocation("Test", 0.0, longitude, 0.0, tz);
+			AstronomicalCalendar calendar = new AstronomicalCalendar(location);
+
+			// Set a specific date
+			calendar.getCalendar().set(2024, Calendar.JUNE, 15, 12, 0, 0);
+			int inputDay = calendar.getCalendar().get(Calendar.DAY_OF_MONTH);
+
+			Date sunTransit = calendar.getSunTransit();
+			Assert.assertNotNull("Sun transit should not be null for longitude " + longitude, sunTransit);
+
+			Calendar result = Calendar.getInstance(tz);
+			result.setTime(sunTransit);
+			int resultDay = result.get(Calendar.DAY_OF_MONTH);
+
+			Assert.assertEquals(
+					"Solar noon day should match input day for longitude " + longitude,
+					inputDay, resultDay);
+		}
+	}
 }


### PR DESCRIPTION
This PR addresses several critical bugs and inconsistencies in KosherJava related to date validation, time zone handling, and calendar calculations.

### WIP

This PR is a Draft. If more issues are bugs are found, this PR will be updated with fixes for them.

### Changes

#### 1. **Enhanced Date Validation in `JewishDate`**
`JewishDate` now properly validates that the day of the month does not exceed the maximum for that specific month and year. Previously, validation only checked that the day was less than 30, which was inadequate since many Jewish months have fewer than 30 days. The constructor now throws an `IllegalArgumentException` for invalid day values.

#### 2. **Standardized UTC Time Zone in `getGregorianCalendar()`**
The `getGregorianCalendar()` method in `JewishDate` now returns a `Calendar` instance with the following standardized values:
- **Time zone**: Set to UTC (instead of the system default time zone)
- **Time fields**: Hours, minutes, seconds, and milliseconds are set to 0 (instead of the current system time)

This ensures consistent, predictable behavior regardless of the system's time zone and time of day.

#### 3. **Fixed Yerushalmi Yomi Start Date Time Zone**
The `DAF_YOMI_START_DAY` constant in `YerushalmiYomiCalculator` now explicitly sets its time zone to UTC instead of using the system default time zone, ensuring consistent calculations across all time zones.

#### 4. **UTC-Based Yerushalmi Yomi Calculations**
All `Calendar` instances used in Yerushalmi Yomi calculations now use UTC time zone, eliminating time zone-related calculation errors.

#### 5. **Replaced Legacy `Calendar.add()` with Modern Date-Time API**
Replaced all instances of `Calendar.add(Calendar.DAY_OF_MONTH, n)` with a helper method that converts to `ZonedDateTime` for date arithmetic. This change addresses numerous inaccuracies in Java's legacy `java.util.Calendar` API, particularly around daylight saving time transitions and month boundaries.

#### 6. **Corrected `getLocalMeanTimeOffset()` Implementation**
Updated the `getLocalMeanTimeOffset()` method to:
- Account for the time zone offset at the specific location
- Use the modern Java date-time API (`java.time`) instead of the legacy API
- Fix incorrect offset calculations that existed in the old implementation

#### 7. **Modernized `getJulianDay()` Implementation**
Updated `getJulianDay()` to use `ZonedDateTime` for extracting day, month, and year values, fixing multiple issues caused by the legacy Java standard library's date handling.

#### 8. **Null Safety in `getMoladBasedTime()`**
Added null-argument handling to `getMoladBasedTime()` to prevent `NullPointerException` when null arguments are passed.


#### 8. **Null return from in `getDafYomiYerushalmi()` on transition dates**
This method would return `null` on the dates of a brand new cycle. This PR fixes that.

#### 9. **Forwarding a` JewishDate` by a month return invalid date**
If adding a month to a date would result in an invalid date (Nissan 30 -> Iyar 30), we return the last day of that month (Iyar 29).

#### 10. **Don't jump a day when calculating Chatzos near the anti-meridian**
If adding a month to a date would result in an invalid date (Nissan 30 -> Iyar 30), we return the last day of that month (Iyar 29).


### Checklist

- [ ] Add tests for each of these changes
- [ ] Investigate whether these changes are considered breaking