### PR TITLE
Migrate to LocalDate, Fix some bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 zmanim.iml
 .gradle
 build
+local.properties

--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -24,6 +24,8 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.TimeZone;
+
 import com.kosherjava.zmanim.util.AstronomicalCalculator;
 import com.kosherjava.zmanim.util.GeoLocation;
 import com.kosherjava.zmanim.util.ZmanimFormatter;
@@ -663,10 +665,10 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @return the degrees below the horizon after sunset that match the offset in minutes passed it as a parameter. If
 	 *            the calculation can't be computed (no sunset occurs on this day) a {@link Double#NaN} will be returned.
 	 * @deprecated This method is slow and inefficient and should NEVER be used in a loop. This method should be replaced
-	 *            by calls to {@link AstronomicalCalculator#getSolarElevation(Calendar, GeoLocation)}. That method will
+	 *            by calls to {@link AstronomicalCalculator#getSolarElevation(ZonedDateTime, GeoLocation)}. That method will
 	 *            efficiently return the the solar elevation (the sun's position in degrees below (or above) the horizon)
 	 *            at the given time even in the arctic when there is no sunrise.
-	 * @see AstronomicalCalculator#getSolarElevation(Calendar, GeoLocation)
+	 * @see AstronomicalCalculator#getSolarElevation(ZonedDateTime, GeoLocation)
 	 * @see #getSunriseSolarDipFromOffset(double)
 	 */
 	@Deprecated(forRemoval=false)
@@ -870,8 +872,6 @@ public class AstronomicalCalendar implements Cloneable {
 	 * <b>Note:</b> If the {@link java.util.TimeZone} in the cloned {@link com.kosherjava.zmanim.util.GeoLocation} will
 	 * be changed from the original, it is critical that
 	 * {@link com.kosherjava.zmanim.AstronomicalCalendar#getLocalDate()}.
-	 * {@link java.util.Calendar#setTimeZone(TimeZone) setTimeZone(TimeZone)} be called in order for the
-	 * AstronomicalCalendar to output times in the expected offset after being cloned.
 	 * 
 	 * @see java.lang.Object#clone()
 	 */

--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -19,16 +19,18 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import com.kosherjava.zmanim.util.AstronomicalCalculator;
 import com.kosherjava.zmanim.util.GeoLocation;
 import com.kosherjava.zmanim.util.ZmanimFormatter;
 
 /**
  * A Java calendar that calculates astronomical times such as {@link #getSunrise() sunrise}, {@link #getSunset()
- * sunset} and twilight times. This class contains a {@link #getZonedDateTime() zonedDateTime} and can therefore use the standard
+ * sunset} and twilight times. This class contains a {@link #getLocalDate() zonedDateTime} and can therefore use the standard
  * Calendar functionality to change dates etc. The calculation engine used to calculate the astronomical times can be
  * changed to a different implementation by implementing the abstract {@link AstronomicalCalculator} and setting it with
  * the {@link #setAstronomicalCalculator(AstronomicalCalculator)}. A number of different calculation engine
@@ -95,7 +97,7 @@ public class AstronomicalCalendar implements Cloneable {
 	/**
 	 * The <code>ZonedDateTime</code> encapsulated by this class to track the current date used by the class
 	 */
-	private ZonedDateTime zonedDateTime;
+	private LocalDate localDate;
 
 	/**
 	 * the {@link GeoLocation} used for calculations.
@@ -329,7 +331,7 @@ public class AstronomicalCalendar implements Cloneable {
 	public Instant getSunriseOffsetByDegrees(double offsetZenith) {
 	    double dawn = getUTCSunrise(offsetZenith);
 	    return Double.isNaN(dawn) ? null
-	            : getInstantFromTime(dawn, SolarEvent.SUNSET);
+	            : getInstantFromTime(dawn, SolarEvent.SUNRISE);
 	}
 
 	/**
@@ -371,7 +373,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see #setAstronomicalCalculator(AstronomicalCalculator) for changing the calculator class.
 	 */
 	public AstronomicalCalendar(GeoLocation geoLocation) {
-		setZonedDateTime(ZonedDateTime.now(geoLocation.getZoneId()));
+		setLocalDate(LocalDate.now(geoLocation.getZoneId()));
 		setGeoLocation(geoLocation);// duplicate call
 		setAstronomicalCalculator(AstronomicalCalculator.getDefault());
 	}
@@ -387,7 +389,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 *         not set, {@link Double#NaN} will be returned. See detailed explanation on top of the page.
 	 */
 	public double getUTCSunrise(double zenith) {
-		return getAstronomicalCalculator().getUTCSunrise(getAdjustedCalendar(), getGeoLocation(), zenith, true);
+		return getAstronomicalCalculator().getUTCSunrise(getAdjustedLocalDate(), getGeoLocation(), zenith, true);
 	}
 
 	/**
@@ -405,7 +407,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see AstronomicalCalendar#getUTCSeaLevelSunset
 	 */
 	public double getUTCSeaLevelSunrise(double zenith) {
-		return getAstronomicalCalculator().getUTCSunrise(getAdjustedCalendar(), getGeoLocation(), zenith, false);
+		return getAstronomicalCalculator().getUTCSunrise(getAdjustedLocalDate(), getGeoLocation(), zenith, false);
 	}
 
 	/**
@@ -420,7 +422,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see AstronomicalCalendar#getUTCSeaLevelSunset
 	 */
 	public double getUTCSunset(double zenith) {
-		return getAstronomicalCalculator().getUTCSunset(getAdjustedCalendar(), getGeoLocation(), zenith, true);
+		return getAstronomicalCalculator().getUTCSunset(getAdjustedLocalDate(), getGeoLocation(), zenith, true);
 	}
 
 	/**
@@ -439,7 +441,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see AstronomicalCalendar#getUTCSeaLevelSunrise
 	 */
 	public double getUTCSeaLevelSunset(double zenith) {
-		return getAstronomicalCalculator().getUTCSunset(getAdjustedCalendar(), getGeoLocation(), zenith, false);
+		return getAstronomicalCalculator().getUTCSunset(getAdjustedLocalDate(), getGeoLocation(), zenith, false);
 	}
 
 	/**
@@ -506,7 +508,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see com.kosherjava.zmanim.util.SunTimesCalculator#getUTCNoon(Calendar, GeoLocation)
 	 */
 	public Instant getSunTransit() {
-		double noon = getAstronomicalCalculator().getUTCNoon(getAdjustedCalendar(), getGeoLocation());
+		double noon = getAstronomicalCalculator().getUTCNoon(getAdjustedLocalDate(), getGeoLocation());
 		return getInstantFromTime(noon, SolarEvent.NOON); //FIXME NEW CODE
 	}
 	
@@ -536,7 +538,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see com.kosherjava.zmanim.util.SunTimesCalculator#getUTCNoon(Calendar, GeoLocation)
 	 */
 	public Instant getSolarMidnight() {
-		double noon = getAstronomicalCalculator().getUTCMidnight(getAdjustedCalendar(), getGeoLocation());
+		double noon = getAstronomicalCalculator().getUTCMidnight(getAdjustedLocalDate(), getGeoLocation());
 		return getInstantFromTime(noon, SolarEvent.MIDNIGHT);
 	}
 
@@ -589,35 +591,27 @@ public class AstronomicalCalendar implements Cloneable {
 	        return null;
 	    }
 
-	    ZonedDateTime adjustedZonedDateTime = getAdjustedZonedDateTime();
+        LocalDate date = getAdjustedLocalDate();
 
-	    LocalDate date = adjustedZonedDateTime
-	            .withZoneSameInstant(ZoneOffset.UTC)
-	            .toLocalDate();
+	    double localTimeHours = (getGeoLocation().getLongitude() / 15) + time;
 
-	    // Convert fractional hour to total seconds
-	    int totalSeconds = (int) Math.floor(time * 3600);
-	    int hours = totalSeconds / 3600;
-	    int minutes = (totalSeconds % 3600) / 60;
-	    int seconds = totalSeconds % 60;
-	    int localTimeHours = (int) getGeoLocation().getLongitude() / 15;
-
-	    if (solarEvent == SolarEvent.SUNRISE && localTimeHours + hours > 18) {
+	    if (solarEvent == SolarEvent.SUNRISE && localTimeHours > 18) {
 	        date = date.minusDays(1);
-	    } else if (solarEvent == SolarEvent.SUNSET && localTimeHours + hours < 6) {
+	    } else if (solarEvent == SolarEvent.SUNSET && localTimeHours < 6) {
 	        date = date.plusDays(1);
-	    } else if (solarEvent == SolarEvent.MIDNIGHT && localTimeHours + hours < 12) {
+	    } else if (solarEvent == SolarEvent.MIDNIGHT && localTimeHours < 12) {
 	        date = date.plusDays(1);
 	    } else if (solarEvent == SolarEvent.NOON) {
-	        if (localTimeHours + hours < 0) {
+	        if (localTimeHours < 0) {
 	            date = date.plusDays(1);
-	        } else if (localTimeHours + hours > 24) {
+	        } else if (localTimeHours > 24) {
 	            date = date.minusDays(1);
 	        }
 	    }
+        LocalDateTime dateTime = date.atStartOfDay().plusSeconds((long) (time*3600));
 
-	    LocalTime localTime = LocalTime.of(hours, minutes, seconds);
-	    return ZonedDateTime.of(date, localTime, ZoneOffset.UTC).toInstant();
+	    // The computed time is in UTC fractional hours; anchor in UTC before converting.
+	    return ZonedDateTime.of(dateTime, ZoneOffset.UTC).toInstant();
 	}
 
 	/**
@@ -718,39 +712,42 @@ public class AstronomicalCalendar implements Cloneable {
 	        throw new IllegalArgumentException("Hours must be between 0 and 23.9999...");
 	    }
 
-	    double rawOffset = getGeoLocation().getZoneId().getRules().getStandardOffset(getZonedDateTime().toInstant()).getTotalSeconds() * 1000;
+	    double rawOffset = getGeoLocation().getZoneId().getRules().getOffset(getMidnightLastNight().toInstant()).getTotalSeconds() * 1000;
 	    double utcTime = hours - rawOffset / (double) HOUR_MILLIS;
 	    Instant instant = getInstantFromTime(utcTime, SolarEvent.SUNRISE);
 
-	    return getTimeOffset(instant, -getGeoLocation().getLocalMeanTimeOffset(getZonedDateTime().toInstant()));
+	    return getTimeOffset(instant, -getGeoLocation().getLocalMeanTimeOffset(getMidnightLastNight().toInstant()));
 	}
-	
+
 	/**
 	 * Adjusts the <code>ZonedDateTime</code> to deal with edge cases where the location crosses the antimeridian.
 	 * 
 	 * @see GeoLocation#getAntimeridianAdjustment(Instant)
 	 * @return the adjusted Calendar
 	 */
-	private ZonedDateTime getAdjustedCalendar(){
-		int offset = getGeoLocation().getAntimeridianAdjustment(getZonedDateTime().toInstant());
-		if (offset == 0) {
-			return getZonedDateTime();
-		}
-		ZonedDateTime adjustedZonedDateTime = getZonedDateTime();
-		return adjustedZonedDateTime.plusDays(1);
+	private LocalDate getAdjustedLocalDate(){
+    	int offset = getGeoLocation().getAntimeridianAdjustment(getMidnightLastNight().toInstant());
+    	return offset == 0 ? getLocalDate() : getLocalDate().plusDays(offset);
 	}
-	
-	/**
-	 * Adjusts the <code>ZonedDateTime</code> to deal with edge cases where the location crosses the antimeridian.
-	 * 
-	 * @see GeoLocation#getAntimeridianAdjustment(Instant)
-	 * @return the adjusted Calendar
-	 */
-	private ZonedDateTime getAdjustedZonedDateTime(){
-		ZonedDateTime adjustedZonedDateTime = getZonedDateTime();
-    	int offset = getGeoLocation().getAntimeridianAdjustment(getZonedDateTime().toInstant());
-    	return offset == 0 ? adjustedZonedDateTime : adjustedZonedDateTime.plusDays(offset);
-	}
+    
+    /**
+     * Used by Molad based <em>zmanim</em> to determine if <em>zmanim</em> occur during the current day.
+     * This is also used as the anchor for current timezone-offset calculations.
+     * @see #getMoladBasedTime(Instant, Instant, Instant, boolean)
+     * @return midnight at the start of the current local date in the configured timezone
+     */
+    protected ZonedDateTime getMidnightLastNight() {
+        return ZonedDateTime.of(getLocalDate(),LocalTime.MIDNIGHT,getGeoLocation().getZoneId());
+    }
+
+    /**
+     * Used by Molad based <em>zmanim</em> to determine if <em>zmanim</em> occur during the current day.
+     * @see #getMoladBasedTime(Instant, Instant, Instant, boolean)
+     * @return following midnight
+     */
+    protected ZonedDateTime getMidnightTonight() {
+        return ZonedDateTime.of(getLocalDate().plusDays(1),LocalTime.MIDNIGHT,getGeoLocation().getZoneId());
+    }
 
 	/**
 	 * Returns an XML formatted representation of the class using the default output of the
@@ -787,7 +784,7 @@ public class AstronomicalCalendar implements Cloneable {
 			return false;
 		}
 		AstronomicalCalendar aCal = (AstronomicalCalendar) object;
-		return getZonedDateTime().equals(aCal.getZonedDateTime()) && getGeoLocation().equals(aCal.getGeoLocation())
+		return getLocalDate().equals(aCal.getLocalDate()) && getGeoLocation().equals(aCal.getGeoLocation())
 				&& getAstronomicalCalculator().equals(aCal.getAstronomicalCalculator());
 	}
 
@@ -797,7 +794,7 @@ public class AstronomicalCalendar implements Cloneable {
 	public int hashCode() {
 		int result = 17;
 		result = 37 * result + getClass().hashCode(); // needed or this and subclasses will return identical hash
-		result += 37 * result + getZonedDateTime().hashCode();
+		result += 37 * result + getLocalDate().hashCode();
 		result += 37 * result + getGeoLocation().hashCode();
 		result += 37 * result + getAstronomicalCalculator().hashCode();
 		return result;
@@ -823,7 +820,6 @@ public class AstronomicalCalendar implements Cloneable {
 	 */
 	public void setGeoLocation(GeoLocation geoLocation) {
 		this.geoLocation = geoLocation;
-		getZonedDateTime().withZoneSameInstant(getGeoLocation().getZoneId());
 	}
 
 	/**
@@ -856,27 +852,24 @@ public class AstronomicalCalendar implements Cloneable {
 	 * 
 	 * @return Returns the ZonedDateTime.
 	 */
-	public ZonedDateTime getZonedDateTime() {
-		return this.zonedDateTime;
+	public LocalDate getLocalDate() {
+		return this.localDate;
 	}
 	
 	/**
 	 * Sets the <code>ZonedDateTime</code>  object for us in this class.
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            The <code>ZonedDateTime</code> to set.
 	 */
-	public void setZonedDateTime(ZonedDateTime zonedDateTime) {
-		this.zonedDateTime = zonedDateTime;
-		if (getGeoLocation() != null) {// if available set the Calendar's timezone to the GeoLocation TimeZone
-			getZonedDateTime().withZoneSameInstant(getGeoLocation().getZoneId());
-		}
+	public void setLocalDate(LocalDate localDate) {
+		this.localDate = localDate;
 	}
 
 	/**
 	 * A method that creates a <a href="https://en.wikipedia.org/wiki/Object_copy#Deep_copy">deep copy</a> of the object.
 	 * <b>Note:</b> If the {@link java.util.TimeZone} in the cloned {@link com.kosherjava.zmanim.util.GeoLocation} will
 	 * be changed from the original, it is critical that
-	 * {@link com.kosherjava.zmanim.AstronomicalCalendar#getZonedDateTime()}.
+	 * {@link com.kosherjava.zmanim.AstronomicalCalendar#getLocalDate()}.
 	 * {@link java.util.Calendar#setTimeZone(TimeZone) setTimeZone(TimeZone)} be called in order for the
 	 * AstronomicalCalendar to output times in the expected offset after being cloned.
 	 * 

--- a/src/main/java/com/kosherjava/zmanim/ComprehensiveZmanimCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/ComprehensiveZmanimCalendar.java
@@ -15,6 +15,7 @@
  */
 package com.kosherjava.zmanim;
 
+import java.time.LocalDate;
 import java.util.Calendar; // FIXME remove once FORWARD can be refactored.
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -3254,7 +3255,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanKidushLevanaBetweenMoldos(Instant alos, Instant tzais) {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 
@@ -3289,8 +3290,8 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 *         returned.
 	 */
 	private Instant getMoladBasedTime(Instant moladBasedTime, Instant alos, Instant tzais, boolean techila) {
-		Instant lastMidnight = getMidnightLastNight();
-	    Instant midnightTonight = getMidnightTonight();
+		Instant lastMidnight = getMidnightLastNight().toInstant();
+	    Instant midnightTonight = getMidnightTonight().toInstant();
 		if(moladBasedTime.isBefore(lastMidnight) || moladBasedTime.isAfter(midnightTonight)){ // Invalid time, bailout
 			return null;
 		} else if (alos == null || tzais == null){ // Not enough info to adjust
@@ -3358,7 +3359,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	public Instant getSofZmanKidushLevana15Days(Instant alos, Instant tzais) {
 		JewishCalendar jewishCalendar = new JewishCalendar();
 		
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		// Do not calculate for impossible dates, but account for extreme cases. In the extreme case of Rapa Iti in
@@ -3437,7 +3438,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	public Instant getTchilasZmanKidushLevana3Days(Instant alos, Instant tzais) {
 		JewishCalendar jewishCalendar = new JewishCalendar();
 		
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		
@@ -3477,7 +3478,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	public Instant getZmanMolad() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
 		
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		
@@ -3495,28 +3496,6 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 			molad = getMoladBasedTime(jewishCalendar.getMoladAsInstant(), null, null, true);
 		}
 		return molad;
-	}
-	
-	/**
-	 * Used by Molad based <em>zmanim</em> to determine if <em>zmanim</em> occur during the current day.
-	 * @see #getMoladBasedTime(Instant, Instant, Instant, boolean)
-	 * @return previous midnight
-	 */
-	private Instant getMidnightLastNight() {
-	    ZonedDateTime midnight = getZonedDateTime().truncatedTo(ChronoUnit.DAYS);
-	    return midnight.toInstant();
-	}
-	
-	/**
-	 * Used by Molad based <em>zmanim</em> to determine if <em>zmanim</em> occur during the current day.
-	 * @see #getMoladBasedTime(Instant, Instant, Instant, boolean)
-	 * @return following midnight
-	 */
-	private Instant getMidnightTonight() {
-        return getZonedDateTime()
-	        .plusDays(1)
-	        .truncatedTo(ChronoUnit.DAYS)
-	        .toInstant();
 	}
 
 	/**
@@ -3543,7 +3522,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getTchilasZmanKidushLevana7Days(Instant alos, Instant tzais) {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 		
 		// Optimize to not calculate for impossible dates, but account for extreme cases. Tchilas zman kiddush Levana 7 days for
@@ -3591,7 +3570,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanAchilasChametzGRA() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) { 
@@ -3621,7 +3600,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanAchilasChametzMGA72Minutes() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
@@ -3652,7 +3631,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	public Instant getSofZmanAchilasChametzMGA72MinutesZmanis() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
 		
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
@@ -3682,7 +3661,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	public Instant getSofZmanAchilasChametzMGA16Point1Degrees() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
 		
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
@@ -3707,7 +3686,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanBiurChametzGRA() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
@@ -3735,7 +3714,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanBiurChametzMGA72Minutes() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
@@ -3763,7 +3742,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanBiurChametzMGA72MinutesZmanis() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
@@ -3793,7 +3772,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanBiurChametzMGA16Point1Degrees() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		
@@ -3969,7 +3948,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanAchilasChametzBaalHatanya() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
@@ -3992,7 +3971,7 @@ public class ComprehensiveZmanimCalendar extends ZmanimCalendar {
 	 */
 	public Instant getSofZmanBiurChametzBaalHatanya() {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		ZonedDateTime zdt = getZonedDateTime();
+		LocalDate zdt = getLocalDate();
 		jewishCalendar.setGregorianDate(zdt.getYear(), zdt.getMonthValue() - 1, zdt.getDayOfMonth()); //FIXME - the minus one needs adjustment when the JewishCalendar is changed to use ZonedDateTime
 		if (jewishCalendar.getJewishMonth() == JewishCalendar.NISSAN && jewishCalendar.getJewishDayOfMonth() == 14) {
 			return getTimeOffset(getSunriseBaalHatanya(), getShaahZmanisBaalHatanya() * 5);

--- a/src/main/java/com/kosherjava/zmanim/ZmanimCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/ZmanimCalendar.java
@@ -1084,8 +1084,8 @@ public class ZmanimCalendar extends AstronomicalCalendar {
 	 */
 	public boolean isAssurBemlacha(Instant currentTime, Instant tzais, boolean inIsrael) {
 		JewishCalendar jewishCalendar = new JewishCalendar();
-		jewishCalendar.setGregorianDate(getZonedDateTime().getYear(),getZonedDateTime().getMonthValue(),
-				getZonedDateTime().getDayOfMonth());
+		jewishCalendar.setGregorianDate(getLocalDate().getYear(), getLocalDate().getMonthValue(),
+				getLocalDate().getDayOfMonth());
 		
 		jewishCalendar.setInIsrael(inIsrael);
 		

--- a/src/main/java/com/kosherjava/zmanim/ZmanimCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/ZmanimCalendar.java
@@ -16,6 +16,8 @@
 package com.kosherjava.zmanim;
 
 import java.time.Instant;
+import java.time.LocalDate;
+
 import com.kosherjava.zmanim.hebrewcalendar.JewishCalendar;
 import com.kosherjava.zmanim.util.AstronomicalCalculator;
 import com.kosherjava.zmanim.util.GeoLocation;
@@ -399,9 +401,9 @@ public class ZmanimCalendar extends AstronomicalCalendar {
 	 * zmaniyos</em> after sunrise. See <a href="https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition
 	 * of <em>Chatzos</em></a> for a detailed explanation of the ways to calculate <em>Chatzos</em>.
 	 *
-	 * @see com.kosherjava.zmanim.util.NOAACalculator#getUTCNoon(ZonedDateTime, GeoLocation)
-	 * @see com.kosherjava.zmanim.util.SunTimesCalculator#getUTCNoon(ZonedDateTime, GeoLocation)
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(ZonedDateTime, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.NOAACalculator#getUTCNoon(LocalDate, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.SunTimesCalculator#getUTCNoon(LocalDate, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
 	 * @see AstronomicalCalendar#getSunTransit(Instant, Instant)
 	 * @see #getChatzos()
 	 * @see #getSunTransit()

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishCalendar.java
@@ -1276,7 +1276,7 @@ public class JewishCalendar extends JewishDate {
 	 * @return the Date representing the moment 3 days after the molad.
 	 * 
 	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getTchilasZmanKidushLevana3Days()
-	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getTchilasZmanKidushLevana3Days(Date, Date)
+	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getTchilasZmanKidushLevana3Days(Instant, Instant)
 	 */
 	public Instant getTchilasZmanKidushLevana3Days() {
 	    return getMoladAsInstant().plus(Duration.ofHours(72)); // 3 days after the molad
@@ -1292,7 +1292,7 @@ public class JewishCalendar extends JewishDate {
 	 * @return the Date representing the moment 7 days after the molad.
 	 * 
 	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getTchilasZmanKidushLevana7Days()
-	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getTchilasZmanKidushLevana7Days(Date, Date)
+	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getTchilasZmanKidushLevana7Days(Instant, Instant)
 	 */
 	public Instant getTchilasZmanKidushLevana7Days() {
 	    return getMoladAsInstant().plus(Duration.ofHours(168)); // 7 days after the molad
@@ -1311,7 +1311,7 @@ public class JewishCalendar extends JewishDate {
 	 * 
 	 * @see #getSofZmanKidushLevana15Days()
 	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getSofZmanKidushLevanaBetweenMoldos()
-	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getSofZmanKidushLevanaBetweenMoldos(Date, Date)
+	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getSofZmanKidushLevanaBetweenMoldos(Instant, Instant)
 	 */
 	public Instant getSofZmanKidushLevanaBetweenMoldos() {
 	    Instant molad = getMoladAsInstant();
@@ -1342,7 +1342,7 @@ public class JewishCalendar extends JewishDate {
 	 * @return the Date representing the moment 15 days after the <em>molad</em>.
 	 * @see #getSofZmanKidushLevanaBetweenMoldos()
 	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getSofZmanKidushLevana15Days()
-	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getSofZmanKidushLevana15Days(Date, Date)
+	 * @see com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getSofZmanKidushLevana15Days(Instant, Instant)
 	 */
 	public Instant getSofZmanKidushLevana15Days() {
 	    return getMoladAsInstant().plus(Duration.ofHours(24 * 15));

--- a/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
@@ -15,6 +15,7 @@
  */
 package com.kosherjava.zmanim.util;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 /**
@@ -104,7 +105,7 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * A method that calculates UTC sunrise as well as any time based on an angle above or below sunrise. This abstract
 	 * method is implemented by the classes that extend this class.
 	 * 
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
@@ -121,14 +122,14 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 *         {@link java.lang.Double#NaN} will be returned.
 	 * @see #getElevationAdjustment(double)
 	 */
-	public abstract double getUTCSunrise(ZonedDateTime zonedDateTime, GeoLocation geoLocation, double zenith,
+	public abstract double getUTCSunrise(LocalDate localDate, GeoLocation geoLocation, double zenith,
 			boolean adjustForElevation);
 
 	/**
 	 * A method that calculates UTC sunset as well as any time based on an angle above or below sunset. This abstract
 	 * method is implemented by the classes that extend this class.
 	 * 
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
@@ -145,7 +146,7 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 *         {@link java.lang.Double#NaN} will be returned.
 	 * @see #getElevationAdjustment(double)
 	 */
-	public abstract double getUTCSunset(ZonedDateTime zonedDateTime, GeoLocation geoLocation, double zenith,
+	public abstract double getUTCSunset(LocalDate localDate, GeoLocation geoLocation, double zenith,
 			boolean adjustForElevation);
 	
 	
@@ -155,14 +156,14 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * true solar noon, while the {@link com.kosherjava.zmanim.util.SunTimesCalculator} approximates it, calculating
 	 * the time as halfway between sunrise and sunset.
 	 * 
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.         
 	 * 
 	 * @return the time in minutes from zero UTC
 	 */
-	public abstract double getUTCNoon(ZonedDateTime zonedDateTime, GeoLocation geoLocation);
+	public abstract double getUTCNoon(LocalDate localDate, GeoLocation geoLocation);
 	
 	
 	/**
@@ -171,21 +172,21 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * true solar midnight, while the {@link com.kosherjava.zmanim.util.SunTimesCalculator} approximates it, calculating
 	 * the time as 12 hours after halfway between sunrise and sunset.
 	 * 
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.         
 	 * 
 	 * @return the time in minutes from zero UTC
 	 */
-	public abstract double getUTCMidnight(ZonedDateTime zonedDateTime, GeoLocation geoLocation);
+	public abstract double getUTCMidnight(LocalDate localDate, GeoLocation geoLocation);
 	
 	/**
 	 * Return the <a href="https://en.wikipedia.org/wiki/Celestial_coordinate_system">Solar Elevation</a> for the
 	 * horizontal coordinate system at the given location at the given time. Can be negative if the sun is below the
 	 * horizon. Not corrected for altitude.
 	 * 
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            time of calculation
 	 * @param geoLocation
 	 *            The location information
@@ -200,7 +201,7 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * horizontal coordinate system at the given location at the given time. Not corrected for altitude. True south is 180
 	 * degrees.
 	 * 
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            time of calculation
 	 * @param geoLocation
 	 *            The location information

--- a/src/main/java/com/kosherjava/zmanim/util/GeoLocation.java
+++ b/src/main/java/com/kosherjava/zmanim/util/GeoLocation.java
@@ -342,7 +342,7 @@ public class GeoLocation implements Cloneable {
 	 */
 	public long getLocalMeanTimeOffset(Instant instant) {
 		ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, zoneId);
-		long timezoneOffsetMillis = zonedDateTime.getOffset().getTotalSeconds() * 1000;
+		long timezoneOffsetMillis = zonedDateTime.getOffset().getTotalSeconds() * 1000L;
 		return (long) (getLongitude() * 4 * MINUTE_MILLIS - timezoneOffsetMillis);
 	}
 	
@@ -695,7 +695,7 @@ public class GeoLocation implements Cloneable {
 	 * An implementation of the {@link java.lang.Object#clone()} method that creates a <a
 	 * href="https://en.wikipedia.org/wiki/Object_copy#Deep_copy">deep copy</a> of the object.
 	 * <b>Note:</b> If the {@link java.time.ZoneId} in the clone will be changed from the original, it is critical
-	 * that {@link com.kosherjava.zmanim.AstronomicalCalendar#getZonedDateTime()}.
+	 * that {@link com.kosherjava.zmanim.AstronomicalCalendar#getLocalDate()}.
 	 * 
 	 * @see java.lang.Object#clone()
 	 */

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -16,6 +16,7 @@
 package com.kosherjava.zmanim.util;
 
 import java.time.ZoneOffset;
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 /**
@@ -71,10 +72,10 @@ public class NOAACalculator extends AstronomicalCalculator {
 	/**
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunrise(ZonedDateTime zdt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
+	public double getUTCSunrise(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
 		double adjustedZenith = adjustZenith(zenith, elevation);
-		double sunrise = getSunRiseSetUTC(zdt, geoLocation.getLatitude(), -geoLocation.getLongitude(),
+		double sunrise = getSunRiseSetUTC(dt, geoLocation.getLatitude(), -geoLocation.getLongitude(),
 				adjustedZenith, SolarEvent.SUNRISE);
 		sunrise = sunrise / 60;
 		return sunrise > 0  ? sunrise % 24 : sunrise % 24 + 24; // ensure that the time is >= 0 and < 24
@@ -83,10 +84,10 @@ public class NOAACalculator extends AstronomicalCalculator {
 	/**
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunset(ZonedDateTime zdt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
+	public double getUTCSunset(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
 		double adjustedZenith = adjustZenith(zenith, elevation);
-		double sunset = getSunRiseSetUTC(zdt, geoLocation.getLatitude(), -geoLocation.getLongitude(),
+		double sunset = getSunRiseSetUTC(dt, geoLocation.getLatitude(), -geoLocation.getLongitude(),
 				adjustedZenith, SolarEvent.SUNSET);
 		sunset = sunset / 60;
 		return sunset > 0  ? sunset % 24 : sunset % 24 + 24; // ensure that the time is >= 0 and < 24
@@ -95,15 +96,15 @@ public class NOAACalculator extends AstronomicalCalculator {
 	/**
 	 * Return the <a href="https://en.wikipedia.org/wiki/Julian_day">Julian day</a> from a Java Calendar.
 	 * 
-	 * @param zonedDateTime
-	 *            The ZonedDateTime
+	 * @param localDate
+	 *            The LocalDate
 	 * @return the Julian day corresponding to the date Note: Number is returned for the start of the Julian
 	 *         day. Fractional days / time should be added later.
 	 */
-	private static double getJulianDay(ZonedDateTime zonedDateTime) {
-	    int year = zonedDateTime.getYear();
-	    int month = zonedDateTime.getMonthValue();
-	    int day = zonedDateTime.getDayOfMonth();
+	private static double getJulianDay(LocalDate localDate) {
+	    int year = localDate.getYear();
+	    int month = localDate.getMonthValue();
+	    int day = localDate.getDayOfMonth();
 
 	    if (month <= 2) {
 	        year -= 1;
@@ -313,16 +314,16 @@ public class NOAACalculator extends AstronomicalCalculator {
 	/**
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(Calendar, GeoLocation)
 	 */
-	public double getSolarElevation(ZonedDateTime zdt, GeoLocation geoLocation) {
-		return getSolarElevationAzimuth(zdt, geoLocation, false);
+	public double getSolarElevation(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
+		return getSolarElevationAzimuth(zonedDateTime, geoLocation, false);
 
 	}
 	
 	/**
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(Calendar, GeoLocation)
 	 */
-	public double getSolarAzimuth(ZonedDateTime zdt, GeoLocation geoLocation) {
-		return getSolarElevationAzimuth(zdt, geoLocation, true);
+	public double getSolarAzimuth(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
+		return getSolarElevationAzimuth(zonedDateTime, geoLocation, true);
 	}
 
 	/**
@@ -331,7 +332,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * and time. Can be negative if the sun is below the horizon. Elevation is based on sea-level and is not
 	 * adjusted for altitude.
 	 * 
-	 * @param zonedDateTime
+	 * @param localDate
 	 *            time of calculation
 	 * @param geoLocation
 	 *            The location for calculating the elevation or azimuth.
@@ -347,14 +348,14 @@ public class NOAACalculator extends AstronomicalCalculator {
 	    double lat = Math.toRadians(geoLocation.getLatitude());
 	    double lon = geoLocation.getLongitude();
 
-	    ZonedDateTime utc = zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
+        ZonedDateTime utc = zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
 
 	    double fractionalDay =
 	            (utc.getHour()
 	            + (utc.getMinute()
 	            + (utc.getSecond() + utc.getNano() / 1_000_000_000.0) / 60.0) / 60.0) / 24.0;
 
-	    double jd = getJulianDay(utc) + fractionalDay;
+	    double jd = getJulianDay(utc.toLocalDate()) + fractionalDay;
 	    double jc = getJulianCenturiesFromJulianDay(jd);
 
 	    double decl = Math.toRadians(getSunDeclination(jc));
@@ -396,15 +397,15 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see #getSolarNoonMidnightUTC(double, double, SolarEvent)
 	 * 
-	 * @param zonedDateTime
-	 *            The zonedDateTime representing the date to calculate solar noon for
+	 * @param localDate
+	 *            The localDate representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times. This class uses only requires
 	 *            the longitude for calculating noon since it is the same time anywhere along the longitude line.
 	 * @return the time in minutes from zero UTC
 	 */
-	public double getUTCNoon(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
-		double noon = getSolarNoonMidnightUTC(getJulianDay(zonedDateTime), -geoLocation.getLongitude(), SolarEvent.NOON);
+	public double getUTCNoon(LocalDate localDate, GeoLocation geoLocation) {
+		double noon = getSolarNoonMidnightUTC(getJulianDay(localDate), -geoLocation.getLongitude(), SolarEvent.NOON);
 		noon = noon / 60;
 		return noon > 0  ? noon % 24 : noon % 24 + 24; // ensure that the time is >= 0 and < 24
 	}
@@ -420,15 +421,15 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see #getSolarNoonMidnightUTC(double, double, SolarEvent)
 	 * 
-	 * @param zonedDateTime
-	 *            The <code>ZonedDateTime</code> representing the date to calculate solar noon for
+	 * @param localDate
+	 *            The <code>LocalDate</code> representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times. This class uses only requires
 	 *            the longitude for calculating noon since it is the same time anywhere along the longitude line.
 	 * @return the time in minutes from zero UTC
 	 */
-	public double getUTCMidnight(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
-		double midnight = getSolarNoonMidnightUTC(getJulianDay(zonedDateTime), -geoLocation.getLongitude(), SolarEvent.MIDNIGHT);
+	public double getUTCMidnight(LocalDate localDate, GeoLocation geoLocation) {
+		double midnight = getSolarNoonMidnightUTC(getJulianDay(localDate), -geoLocation.getLongitude(), SolarEvent.MIDNIGHT);
 		midnight = midnight / 60;
 		return midnight > 0  ? midnight % 24 : midnight % 24 + 24; // ensure that the time is >= 0 and < 24
 	}
@@ -469,8 +470,8 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * of sunrise or sunset in minutes for the given day at the given location on earth.
 	 * @todo Possibly increase the number of passes for improved accuracy, especially in the Arctic areas.
 	 * 
-	 * @param zonedDateTime
-	 *            The <code>ZonedDateTime</code>.
+	 * @param localDate
+	 *            The <code>LocalDate</code>.
 	 * @param latitude
 	 *            The latitude of observer in degrees
 	 * @param longitude
@@ -481,9 +482,9 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 *             If the calculation is for {@link SolarEvent#SUNRISE SUNRISE} or {@link SolarEvent#SUNSET SUNSET}
 	 * @return the time in minutes from zero Universal Coordinated Time (UTC)
 	 */
-	private static double getSunRiseSetUTC(ZonedDateTime zonedDateTime, double latitude, double longitude, double zenith,
+	private static double getSunRiseSetUTC(LocalDate localDate, double latitude, double longitude, double zenith,
 			SolarEvent solarEvent) {
-		double julianDay = getJulianDay(zonedDateTime);
+		double julianDay = getJulianDay(localDate);
 
 		// Find the time of solar noon at the location, and use that declination.
 		// This is better than start of the Julian day

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -70,7 +70,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(Calendar, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(LocalDate, GeoLocation, double, boolean)
 	 */
 	public double getUTCSunrise(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
@@ -82,7 +82,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(Calendar, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(LocalDate, GeoLocation, double, boolean)
 	 */
 	public double getUTCSunset(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
@@ -312,15 +312,15 @@ public class NOAACalculator extends AstronomicalCalculator {
 	}
 	
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(ZonedDateTime, GeoLocation)
 	 */
 	public double getSolarElevation(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
 		return getSolarElevationAzimuth(zonedDateTime, geoLocation, false);
 
 	}
-	
+
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(ZonedDateTime, GeoLocation)
 	 */
 	public double getSolarAzimuth(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
 		return getSolarElevationAzimuth(zonedDateTime, geoLocation, true);
@@ -332,7 +332,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * and time. Can be negative if the sun is below the horizon. Elevation is based on sea-level and is not
 	 * adjusted for altitude.
 	 * 
-	 * @param localDate
+	 * @param zonedDateTime
 	 *            time of calculation
 	 * @param geoLocation
 	 *            The location for calculating the elevation or azimuth.
@@ -340,8 +340,8 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 *            true for azimuth, false for elevation
 	 * @return solar elevation or azimuth in degrees.
 	 * 
-	 * @see #getSolarElevation(Calendar, GeoLocation)
-	 * @see #getSolarAzimuth(Calendar, GeoLocation)
+	 * @see #getSolarElevation(ZonedDateTime, GeoLocation)
+	 * @see #getSolarAzimuth(ZonedDateTime, GeoLocation)
 	 */
 	private double getSolarElevationAzimuth(ZonedDateTime zonedDateTime, GeoLocation geoLocation, boolean isAzimuth) {
 
@@ -394,7 +394,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * Other calculators may return a more simplified calculation of halfway between sunrise and sunset. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of <em>Chatzos</em></a> for details on
 	 * solar noon calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
 	 * @see #getSolarNoonMidnightUTC(double, double, SolarEvent)
 	 * 
 	 * @param localDate
@@ -418,7 +418,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * simplified calculation of halfway between sunrise and sunset. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of <em>Chatzos</em></a> for details on
 	 * solar noon / midnight calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
 	 * @see #getSolarNoonMidnightUTC(double, double, SolarEvent)
 	 * 
 	 * @param localDate
@@ -449,8 +449,8 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 *            
 	 * @return the time in minutes from zero UTC
 	 * 
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
-	 * @see #getUTCNoon(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
+	 * @see #getUTCNoon(LocalDate, GeoLocation)
 	 */
 	private static double getSolarNoonMidnightUTC(double julianDay, double longitude, SolarEvent solarEvent) {
 		julianDay = (solarEvent == SolarEvent.NOON) ? julianDay : julianDay + 0.5;

--- a/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
@@ -47,7 +47,7 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(Calendar, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(LocalDate, GeoLocation, double, boolean)
 	 */
 	public double getUTCSunrise(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
@@ -56,7 +56,7 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(Calendar, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(LocalDate, GeoLocation, double, boolean
 	 */
 	public double getUTCSunset(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
@@ -263,7 +263,7 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * {@link NOAACalculator}, the default calculator, returns true solar noon. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of Chatzos</a> for details on solar
 	 * noon calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
 	 * @see NOAACalculator
 	 * 
 	 * @param localDate
@@ -293,7 +293,7 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * {@link NOAACalculator}, the default calculator, returns true solar noon. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of Chatzos</a> for details on solar
 	 * noon calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
 	 * @see NOAACalculator
 	 * 
 	 * @param localDate
@@ -308,14 +308,14 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	}
 	
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(ZonedDateTime, GeoLocation)
 	 */
 	public double getSolarAzimuth(ZonedDateTime zdt, GeoLocation geoLocation) {
 		throw new UnsupportedOperationException("The SunTimesCalculator class does not implement the getSolarAzimuth method. Use the NOAACalculator instead.");
 	}
 	
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(Calendar, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(ZonedDateTime, GeoLocation)
 	 */
 	public double getSolarElevation(ZonedDateTime zdt, GeoLocation geoLocation) {
 		throw new UnsupportedOperationException("The SunTimesCalculator class does not implement the getSolarElevation method. Use the NOAACalculator instead.");

--- a/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
@@ -15,6 +15,7 @@
  */
 package com.kosherjava.zmanim.util;
 
+import java.time.LocalDate;
 import java.time.ZonedDateTime;
 
 /**
@@ -48,19 +49,19 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	/**
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunrise(ZonedDateTime zdt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
+	public double getUTCSunrise(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
 		double adjustedZenith = adjustZenith(zenith, elevation);
-		return getTimeUTC(zdt, geoLocation, adjustedZenith, true);
+		return getTimeUTC(dt, geoLocation, adjustedZenith, true);
 	}
 
 	/**
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunset(ZonedDateTime zdt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
+	public double getUTCSunset(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
 		double adjustedZenith = adjustZenith(zenith, elevation);
-		return getTimeUTC(zdt, geoLocation, adjustedZenith, false);
+		return getTimeUTC(dt, geoLocation, adjustedZenith, false);
 	}
 
 	/**
@@ -222,8 +223,8 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * Get sunrise or sunset time in UTC, according to flag. This time is returned as
 	 * a double and is not adjusted for time-zone.
 	 * 
-	 * @param zonedDateTime
-	 *            the <code>ZonedDateTime</code> object to extract the day of year for calculation
+	 * @param localDate
+	 *            the <code>LocalDate</code> object to extract the day of year for calculation
 	 * @param geoLocation
 	 *            the GeoLocation object that contains the latitude and longitude
 	 * @param zenith
@@ -234,8 +235,8 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 *         (expected behavior for some locations such as near the poles,
 	 *         {@link Double#NaN} will be returned.
 	 */
-	private static double getTimeUTC(ZonedDateTime zonedDateTime, GeoLocation geoLocation, double zenith, boolean isSunrise) {
-		int dayOfYear = zonedDateTime.getDayOfYear();
+	private static double getTimeUTC(LocalDate localDate, GeoLocation geoLocation, double zenith, boolean isSunrise) {
+		int dayOfYear = localDate.getDayOfYear();
 		double sunMeanAnomaly = getMeanAnomaly(dayOfYear, geoLocation.getLongitude(), isSunrise);
 		double sunTrueLong = getSunTrueLongitude(sunMeanAnomaly);
 		double sunRightAscensionHours = getSunRightAscensionHours(sunTrueLong);
@@ -265,16 +266,16 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see NOAACalculator
 	 * 
-	 * @param zonedDateTime
-	 *            The <code>ZonedDateTime</code> representing the date to calculate solar noon for
+	 * @param localDate
+	 *            The <code>LocalDate</code> representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
 	 * @return the time in minutes from zero UTC. If an error was encountered in the calculation (expected behavior for
 	 *         some locations such as near the poles, {@link Double#NaN} will be returned.
 	 */
-	public double getUTCNoon(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
-		double sunrise = getUTCSunrise(zonedDateTime, geoLocation, 90, false);
-		double sunset = getUTCSunset(zonedDateTime, geoLocation, 90, false);
+	public double getUTCNoon(LocalDate localDate, GeoLocation geoLocation) {
+		double sunrise = getUTCSunrise(localDate, geoLocation, 90, false);
+		double sunset = getUTCSunset(localDate, geoLocation, 90, false);
 		double noon = sunrise + ((sunset - sunrise) / 2);
 		if (noon < 0) {
 			noon += 12;
@@ -295,15 +296,15 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see NOAACalculator
 	 * 
-	 * @param zonedDateTime
-	 *            The <code>ZonedDateTime</code> representing the date to calculate solar noon for
+	 * @param localDate
+	 *            The <code>LocalDate</code> representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
 	 * @return the time in minutes from zero UTC. If an error was encountered in the calculation (expected behavior for
 	 *         some locations such as near the poles, {@link Double#NaN} will be returned.
 	 */
-	public double getUTCMidnight(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
-		return (getUTCNoon(zonedDateTime, geoLocation) + 12);
+	public double getUTCMidnight(LocalDate localDate, GeoLocation geoLocation) {
+		return (getUTCNoon(localDate, geoLocation) + 12);
 	}
 	
 	/**

--- a/src/main/java/com/kosherjava/zmanim/util/ZmanimFormatter.java
+++ b/src/main/java/com/kosherjava/zmanim/util/ZmanimFormatter.java
@@ -17,6 +17,8 @@ package com.kosherjava.zmanim.util;
 
 import java.lang.reflect.Method;
 import java.text.DecimalFormat;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -277,8 +279,8 @@ public class ZmanimFormatter {
 	 *            settings.
 	 * @return the formatted String
 	 */
-	public String formatDateTime(Instant instant, ZonedDateTime zonedDateTime) {
-	    ZonedDateTime dateTime = instant.atZone(zonedDateTime.getZone());
+	public String formatDateTime(Instant instant, ZoneId zoneId) {
+	    ZonedDateTime dateTime = instant.atZone(zoneId);
 
 	    if (this.dateTimeFormatter.toString().equals("yyyy-MM-dd'T'HH:mm:ss")) {
 	        return getXSDateTime(instant);
@@ -380,7 +382,7 @@ public class ZmanimFormatter {
 		DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 		df = df.withZone(astronomicalCalendar.getGeoLocation().getZoneId());
 
-		Instant instant = astronomicalCalendar.getZonedDateTime().toInstant();
+		LocalDate localDate = astronomicalCalendar.getLocalDate();
 		ZoneId zi = astronomicalCalendar.getGeoLocation().getZoneId();
 
 		StringBuilder sb = new StringBuilder("<");
@@ -400,7 +402,7 @@ public class ZmanimFormatter {
 			// output += "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ";
 			// output += xsi:schemaLocation="http://www.kosherjava.com/zmanim basicZmanim.xsd"
 		}
-		sb.append(" date=\"").append(df.format(instant)).append("\"");
+		sb.append(" date=\"").append(df.format(localDate)).append("\"");
 		sb.append(" type=\"").append(astronomicalCalendar.getClass().getName()).append("\"");
 		sb.append(" algorithm=\"").append(astronomicalCalendar.getAstronomicalCalculator().getCalculatorName()).append("\"");
 		sb.append(" location=\"").append(astronomicalCalendar.getGeoLocation().getLocationName()).append("\"");
@@ -409,7 +411,9 @@ public class ZmanimFormatter {
 		sb.append(" elevation=\"").append(astronomicalCalendar.getGeoLocation().getElevation()).append("\"");
 		sb.append(" timeZoneName=\"").append(zi.getDisplayName(TextStyle.FULL, Locale.getDefault())).append("\"");
 	    sb.append(" timeZoneID=\"").append(zi.getId()).append("\"");
-	    double offsetHours = astronomicalCalendar.getZonedDateTime().getOffset().getTotalSeconds() / 3600.0;
+
+        ZonedDateTime lastMidnight = ZonedDateTime.of(astronomicalCalendar.getLocalDate(), LocalTime.MIDNIGHT, astronomicalCalendar.getGeoLocation().getZoneId());
+	    double offsetHours = lastMidnight.getOffset().getTotalSeconds() / 3600.0;
 	    sb.append(" timeZoneOffset=\"").append(offsetHours).append("\"");
 		//sb.append(" useElevationAllZmanim=\"").append(astronomicalCalendar.useElevationAllZmanim()).append("\""); //TODO likely using reflection
 
@@ -455,7 +459,7 @@ public class ZmanimFormatter {
 		for (int i = 0; i < dateList.size(); i++) {
 			zman = (Zman) dateList.get(i);
 			sb.append("\t<").append(zman.getLabel()).append(">");
-			sb.append(formatter.formatDateTime(zman.getZman(), astronomicalCalendar.getZonedDateTime()));
+			sb.append(formatter.formatDateTime(zman.getZman(), astronomicalCalendar.getGeoLocation().getZoneId()));
 			sb.append("</").append(zman.getLabel()).append(">\n");
 		}
 		Collections.sort(durationList, Zman.DURATION_ORDER);
@@ -539,11 +543,11 @@ public class ZmanimFormatter {
 		DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy-MM-dd")
                 .withZone(astronomicalCalendar.getGeoLocation().getZoneId());
 
-		Instant instant = astronomicalCalendar.getZonedDateTime().toInstant();
+		LocalDate localDate = astronomicalCalendar.getLocalDate();
 		ZoneId zi = astronomicalCalendar.getGeoLocation().getZoneId();
 
 		StringBuilder sb = new StringBuilder("{\n\"metadata\":{\n");
-		sb.append("\t\"date\":\"").append(df.format(instant)).append("\",\n");
+		sb.append("\t\"date\":\"").append(df.format(localDate)).append("\",\n");
 		sb.append("\t\"type\":\"").append(astronomicalCalendar.getClass().getName()).append("\",\n");
 		sb.append("\t\"algorithm\":\"").append(astronomicalCalendar.getAstronomicalCalculator().getCalculatorName()).append("\",\n");
 		sb.append("\t\"location\":\"").append(astronomicalCalendar.getGeoLocation().getLocationName()).append("\",\n");
@@ -554,9 +558,9 @@ public class ZmanimFormatter {
 	    
 		sb.append("\t\"timeZoneName\":\"").append(zi.getDisplayName(TextStyle.FULL, Locale.getDefault())).append("\",\n");
 		sb.append("\t\"timeZoneID\":\"").append(zi.getId()).append("\",\n"); //FIXME
-		
-		
-	    double offsetHours = astronomicalCalendar.getZonedDateTime().getOffset().getTotalSeconds() / 3600.0;
+
+        ZonedDateTime lastMidnight = ZonedDateTime.of(astronomicalCalendar.getLocalDate(), LocalTime.MIDNIGHT, astronomicalCalendar.getGeoLocation().getZoneId());
+        double offsetHours = lastMidnight.getOffset().getTotalSeconds() / 3600.0;
 	    sb.append(" timeZoneOffset=\"").append(offsetHours).append("\"");
 		sb.append("},\n\"");
 		
@@ -603,7 +607,7 @@ public class ZmanimFormatter {
 		for (int i = 0; i < dateList.size(); i++) {
 			zman = (Zman) dateList.get(i);
 			sb.append("\t\"").append(zman.getLabel()).append("\":\"");
-			sb.append(formatter.formatDateTime(zman.getZman(), astronomicalCalendar.getZonedDateTime()));
+			sb.append(formatter.formatDateTime(zman.getZman(), astronomicalCalendar.getGeoLocation().getZoneId()));
 			sb.append("\",\n");
 		}
 		Collections.sort(durationList, Zman.DURATION_ORDER);


### PR DESCRIPTION
This PR will replace `ZonedDateTime` with `LocalDate`. 
The benefit of this change is that the time zone is only in a single location. It is impossible for the timezone in the geolocation class to differ from the timezone in the `ZonedDateTime`.  It also generally makes the entire API more user-friendly. In the past, I've been confused about what time of day the `ZonedDateTime` should use. 

Additionally, this PR fixes a small error in the `getSunriseOffsetByDegrees` function, Where `SolarEvent.SUNSET` was being passed to `getInstantFromTime`.

This PR fixes a bug in `getInstantFromTime`, which simplifies the calculation by offloading the math to the Java Duration class. There was also an issue where the Instant being returned was incorrectly converting to the local timezone.
