### PR TITLE
Use adjusted local date for civil time calculation

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -745,7 +745,7 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see GeoLocation#getLocalMeanTimeOffset(Instant)
 	 */
 	public Instant getLocalMeanTime(LocalTime localTime) {
-	    Instant civilTime = ZonedDateTime.of(getLocalDate(), localTime, getGeoLocation().getZoneId()).toInstant();
+	    Instant civilTime = ZonedDateTime.of(getAdjustedLocalDate(), localTime, getGeoLocation().getZoneId()).toInstant();
 	    return getTimeOffset(civilTime, -getGeoLocation().getLocalMeanTimeOffset(civilTime));
 	}
 


### PR DESCRIPTION
This fixes an issue where the returned time was 24 hours off.

Test Case:
```
{
    "iteration": 741,
    "year": 2058,
    "month": 7,
    "day": 31,
    "latitude": -18.88480386694347,
    "longitude": -174.522379072958,
    "elevation": 2671.332842032057,
    "timezone": "Pacific/Tongatapu",
    "zman": "getFixedLocalChatzos",
    "ateretTorahSunsetOffsetMinutes": 19,
    "candleLightingOffsetMinutes": 6,
    "useAstronomicalChatzosForOtherZmanim": true,
    "useElevation": false
  }
```