### PR TITLE
feature: add support for the geocentric Earth radius

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
@@ -1,6 +1,6 @@
 /*
  * Zmanim Java API
- * Copyright (C) 2004-2025 Eliyahu Hershfeld
+ * Copyright (C) 2004-2026 Eliyahu Hershfeld
  *
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
  * Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option)

--- a/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
@@ -45,24 +45,71 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	/**
 	 * The commonly used average earth radius in KM. At this time, this only affects elevation adjustment and not the
 	 * sunrise and sunset calculations. The value currently defaults to 6356.9 KM.
-	 * 
+	 *
 	 * @see #getEarthRadius()
 	 * @see #setEarthRadius(double)
 	 */
 	private double earthRadius = 6356.9; // in KM
-	
+
+	/**
+	 * WGS84 ellipsoid constants for Earth radius calculation.
+	 * These are used by {@link #getGeocentricRadius(double)} to provide latitude-dependent accuracy.
+	 *
+	 * @see #getGeocentricRadius(double)
+	 */
+	private static final double WGS84_EQUATORIAL_RADIUS = 6378.137; // km
+	private static final double WGS84_POLAR_RADIUS = 6356.752314245; // km
+
 	/**
 	 * Default constructor using the default {@link #refraction refraction}, {@link #solarRadius solar radius} and
 	 * {@link #earthRadius earth radius}.
 	 */
 	public AstronomicalCalculator() {
-		// keep the defaults for now. 
+		// keep the defaults for now.
+	}
+
+	/**
+	 * Calculate geocentric Earth radius at given latitude using WGS84 ellipsoid.
+	 *
+	 * <p>The Earth is an oblate spheroid, so the geocentric radius varies with latitude
+	 * from 6378.137 km at the equator to 6356.752 km at the poles. This method computes
+	 * the precise radius using the WGS84 ellipsoid formula:</p>
+	 *
+	 * <pre>R = sqrt(a² × cos²(lat) + b² × sin²(lat))</pre>
+	 *
+	 * <p>where a is the equatorial radius and b is the polar radius.</p>
+	 *
+	 * <p><b>Usage:</b><br>
+	 * This method is automatically called by {@link com.kosherjava.zmanim.ZmanimCalendar} when elevation
+	 * adjustments are enabled via {@link com.kosherjava.zmanim.ZmanimCalendar#setUseElevation(boolean)}.
+	 * Manual usage: call {@link #setEarthRadius(double)} with the result before calculations.</p>
+	 *
+	 * <p><b>Reference:</b> WGS84 ellipsoid parameters (NGA Technical Report 8350.2)</p>
+	 *
+	 * @param latitude Latitude in degrees (north positive)
+	 * @return Geocentric radius in kilometers at the given latitude
+	 * @see com.kosherjava.zmanim.ZmanimCalendar#setUseElevation(boolean)
+	 */
+	public double getGeocentricRadius(double latitude) {
+		double latRad = Math.toRadians(latitude);
+		double cosLat = Math.cos(latRad);
+		double sinLat = Math.sin(latRad);
+
+		// R = sqrt(a^2 * cos^2(lat) + b^2 * sin^2(lat))
+		double a2 = WGS84_EQUATORIAL_RADIUS * WGS84_EQUATORIAL_RADIUS;
+		double b2 = WGS84_POLAR_RADIUS * WGS84_POLAR_RADIUS;
+
+		return Math.sqrt(a2 * cosLat * cosLat + b2 * sinLat * sinLat);
 	}
 
 	/**
 	 * A method that returns the earth radius in KM. The value currently defaults to 6356.9 KM if not set.
-	 * 
+	 *
+	 * <p><b>Note:</b> For improved accuracy, consider using {@link #getGeocentricRadius(double)} with the
+	 * observer's latitude and calling {@link #setEarthRadius(double)} before calculations.</p>
+	 *
 	 * @return the earthRadius the earth radius in KM.
+	 * @see #getGeocentricRadius(double)
 	 */
 	public double getEarthRadius() {
 		return earthRadius;
@@ -70,9 +117,13 @@ public abstract class AstronomicalCalculator implements Cloneable {
 
 	/**
 	 * A method that allows setting the earth's radius.
-	 * 
+	 *
+	 * <p><b>Note:</b> For improved accuracy based on observer latitude, consider using
+	 * {@link #getGeocentricRadius(double)} to calculate the radius before calling this method.</p>
+	 *
 	 * @param earthRadius
 	 *            the earthRadius to set in KM
+	 * @see #getGeocentricRadius(double)
 	 */
 	public void setEarthRadius(double earthRadius) {
 		this.earthRadius = earthRadius;

--- a/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
@@ -91,33 +91,6 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	}
 
 	/**
-	 * A method that returns the earth radius in KM.
-	 *
-	 * @deprecated Earth radius is now calculated automatically from latitude using the WGS84 ellipsoid
-	 *             in {@link #getElevationAdjustment(double, double)}. This method is retained only for
-	 *             backward compatibility and returns the WGS84 polar radius.
-	 * @return the WGS84 polar radius in KM (6356.752 km).
-	 */
-	@Deprecated
-	public double getEarthRadius() {
-		return WGS84_POLAR_RADIUS;
-	}
-
-	/**
-	 * A method that allows setting the earth's radius.
-	 *
-	 * @deprecated Earth radius is now calculated automatically from latitude using the WGS84 ellipsoid
-	 *             in {@link #getElevationAdjustment(double, double)}. This method is retained only for
-	 *             backward compatibility and has no effect on calculations.
-	 * @param earthRadius
-	 *            the earthRadius to set in KM (ignored)
-	 */
-	@Deprecated
-	public void setEarthRadius(double earthRadius) {
-		// No-op: Earth radius is now calculated automatically from latitude
-	}
-
-	/**
 	 * The zenith of astronomical sunrise and sunset. The sun is 90&deg; from the vertical 0&deg;
 	 */
 	private static final double GEOMETRIC_ZENITH = 90;

--- a/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
@@ -15,7 +15,8 @@
  */
 package com.kosherjava.zmanim.util;
 
-import java.time.LocalDate;\nimport java.time.ZonedDateTime;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
 
 /**
  * An abstract class that all sun time calculating classes extend. This allows the algorithm used to be changed at

--- a/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
@@ -373,3 +373,4 @@ public abstract class AstronomicalCalculator implements Cloneable {
 		return clone;
 	}
 }
+

--- a/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/AstronomicalCalculator.java
@@ -1,6 +1,6 @@
 /*
  * Zmanim Java API
- * Copyright (C) 2004-2026 Eliyahu Hershfeld
+ * Copyright (C) 2004-2025 Eliyahu Hershfeld
  *
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
  * Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option)
@@ -15,8 +15,7 @@
  */
 package com.kosherjava.zmanim.util;
 
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;\nimport java.time.ZonedDateTime;
 
 /**
  * An abstract class that all sun time calculating classes extend. This allows the algorithm used to be changed at
@@ -24,7 +23,7 @@ import java.time.ZonedDateTime;
  * @todo Consider methods that would allow atmospheric modeling. This can currently be adjusted by {@link
  * #setRefraction(double) setting the refraction}.
  * 
- * @author &copy; Eliyahu Hershfeld 2004 - 2026
+ * @author &copy; Eliyahu Hershfeld 2004 - 2025
  */
 public abstract class AstronomicalCalculator implements Cloneable {
 	/**
@@ -43,19 +42,14 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	private double solarRadius = 16 / 60d;
 
 	/**
-	 * The commonly used average earth radius in KM. At this time, this only affects elevation adjustment and not the
-	 * sunrise and sunset calculations. The value currently defaults to 6356.9 KM.
-	 *
-	 * @see #getEarthRadius()
-	 * @see #setEarthRadius(double)
-	 */
-	private double earthRadius = 6356.9; // in KM
-
-	/**
 	 * WGS84 ellipsoid constants for Earth radius calculation.
-	 * These are used by {@link #getGeocentricRadius(double)} to provide latitude-dependent accuracy.
+	 * <p>Earth is an oblate spheroid with radius varying from 6378.137 km at the equator
+	 * to 6356.752 km at the poles. These values are used by {@link #getElevationAdjustment(double, double)}
+	 * to provide latitude-dependent accuracy for elevation adjustments.</p>
 	 *
-	 * @see #getGeocentricRadius(double)
+	 * <p><b>Reference:</b> WGS84 ellipsoid parameters (NGA Technical Report 8350.2)</p>
+	 *
+	 * @see #getElevationAdjustment(double, double)
 	 */
 	private static final double WGS84_EQUATORIAL_RADIUS = 6378.137; // km
 	private static final double WGS84_POLAR_RADIUS = 6356.752314245; // km
@@ -79,18 +73,12 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 *
 	 * <p>where a is the equatorial radius and b is the polar radius.</p>
 	 *
-	 * <p><b>Usage:</b><br>
-	 * This method is automatically called by {@link com.kosherjava.zmanim.ZmanimCalendar} when elevation
-	 * adjustments are enabled via {@link com.kosherjava.zmanim.ZmanimCalendar#setUseElevation(boolean)}.
-	 * Manual usage: call {@link #setEarthRadius(double)} with the result before calculations.</p>
-	 *
 	 * <p><b>Reference:</b> WGS84 ellipsoid parameters (NGA Technical Report 8350.2)</p>
 	 *
 	 * @param latitude Latitude in degrees (north positive)
 	 * @return Geocentric radius in kilometers at the given latitude
-	 * @see com.kosherjava.zmanim.ZmanimCalendar#setUseElevation(boolean)
 	 */
-	public double getGeocentricRadius(double latitude) {
+	private double getGeocentricRadius(double latitude) {
 		double latRad = Math.toRadians(latitude);
 		double cosLat = Math.cos(latRad);
 		double sinLat = Math.sin(latRad);
@@ -103,30 +91,30 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	}
 
 	/**
-	 * A method that returns the earth radius in KM. The value currently defaults to 6356.9 KM if not set.
+	 * A method that returns the earth radius in KM.
 	 *
-	 * <p><b>Note:</b> For improved accuracy, consider using {@link #getGeocentricRadius(double)} with the
-	 * observer's latitude and calling {@link #setEarthRadius(double)} before calculations.</p>
-	 *
-	 * @return the earthRadius the earth radius in KM.
-	 * @see #getGeocentricRadius(double)
+	 * @deprecated Earth radius is now calculated automatically from latitude using the WGS84 ellipsoid
+	 *             in {@link #getElevationAdjustment(double, double)}. This method is retained only for
+	 *             backward compatibility and returns the WGS84 polar radius.
+	 * @return the WGS84 polar radius in KM (6356.752 km).
 	 */
+	@Deprecated
 	public double getEarthRadius() {
-		return earthRadius;
+		return WGS84_POLAR_RADIUS;
 	}
 
 	/**
 	 * A method that allows setting the earth's radius.
 	 *
-	 * <p><b>Note:</b> For improved accuracy based on observer latitude, consider using
-	 * {@link #getGeocentricRadius(double)} to calculate the radius before calling this method.</p>
-	 *
+	 * @deprecated Earth radius is now calculated automatically from latitude using the WGS84 ellipsoid
+	 *             in {@link #getElevationAdjustment(double, double)}. This method is retained only for
+	 *             backward compatibility and has no effect on calculations.
 	 * @param earthRadius
-	 *            the earthRadius to set in KM
-	 * @see #getGeocentricRadius(double)
+	 *            the earthRadius to set in KM (ignored)
 	 */
+	@Deprecated
 	public void setEarthRadius(double earthRadius) {
-		this.earthRadius = earthRadius;
+		// No-op: Earth radius is now calculated automatically from latitude
 	}
 
 	/**
@@ -156,7 +144,7 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * A method that calculates UTC sunrise as well as any time based on an angle above or below sunrise. This abstract
 	 * method is implemented by the classes that extend this class.
 	 * 
-	 * @param localDate
+	 * @param calendar
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
@@ -173,14 +161,14 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 *         {@link java.lang.Double#NaN} will be returned.
 	 * @see #getElevationAdjustment(double)
 	 */
-	public abstract double getUTCSunrise(LocalDate localDate, GeoLocation geoLocation, double zenith,
+	public abstract double getUTCSunrise(Calendar LocalDate localDate, GeoLocation geoLocation, double zenith,
 			boolean adjustForElevation);
 
 	/**
 	 * A method that calculates UTC sunset as well as any time based on an angle above or below sunset. This abstract
 	 * method is implemented by the classes that extend this class.
 	 * 
-	 * @param localDate
+	 * @param calendar
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
@@ -197,7 +185,7 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 *         {@link java.lang.Double#NaN} will be returned.
 	 * @see #getElevationAdjustment(double)
 	 */
-	public abstract double getUTCSunset(LocalDate localDate, GeoLocation geoLocation, double zenith,
+	public abstract double getUTCSunset(Calendar LocalDate localDate, GeoLocation geoLocation, double zenith,
 			boolean adjustForElevation);
 	
 	
@@ -207,14 +195,14 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * true solar noon, while the {@link com.kosherjava.zmanim.util.SunTimesCalculator} approximates it, calculating
 	 * the time as halfway between sunrise and sunset.
 	 * 
-	 * @param localDate
+	 * @param calendar
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.         
 	 * 
 	 * @return the time in minutes from zero UTC
 	 */
-	public abstract double getUTCNoon(LocalDate localDate, GeoLocation geoLocation);
+	public abstract double getUTCNoon(Calendar LocalDate localDate, GeoLocation geoLocation);
 	
 	
 	/**
@@ -223,44 +211,44 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * true solar midnight, while the {@link com.kosherjava.zmanim.util.SunTimesCalculator} approximates it, calculating
 	 * the time as 12 hours after halfway between sunrise and sunset.
 	 * 
-	 * @param localDate
+	 * @param calendar
 	 *            Used to calculate day of year.
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.         
 	 * 
 	 * @return the time in minutes from zero UTC
 	 */
-	public abstract double getUTCMidnight(LocalDate localDate, GeoLocation geoLocation);
+	public abstract double getUTCMidnight(Calendar LocalDate localDate, GeoLocation geoLocation);
 	
 	/**
 	 * Return the <a href="https://en.wikipedia.org/wiki/Celestial_coordinate_system">Solar Elevation</a> for the
 	 * horizontal coordinate system at the given location at the given time. Can be negative if the sun is below the
 	 * horizon. Not corrected for altitude.
 	 * 
-	 * @param zonedDateTime
-	 *            the ZonedDateTime of the time of calculation
+	 * @param calendar
+	 *            time of calculation
 	 * @param geoLocation
 	 *            The location information
 	 * @return solar elevation in degrees. The horizon (calculated in a vacuum using the solar radius as the point)
 	 *            is 090&deg;, civil twilight is -690&deg; etc. This means that sunrise and sunset that do use
 	 *            refraction and are calculated from the upper limb of the sun will return about 0.83390&deg;.
 	 */
-	public abstract double getSolarElevation(ZonedDateTime zonedDateTime, GeoLocation geoLocation);
+	public abstract double getSolarElevation(Calendar LocalDate localDate, GeoLocation geoLocation);
 	
 	/**
 	 * Return the <a href="https://en.wikipedia.org/wiki/Celestial_coordinate_system">Solar Azimuth</a> for the
 	 * horizontal coordinate system at the given location at the given time. Not corrected for altitude. True south is 180
 	 * degrees.
 	 * 
-	 * @param zonedDateTime
-	 *            The ZonedDateTime of the time of calculation.
+	 * @param calendar
+	 *            time of calculation
 	 * @param geoLocation
 	 *            The location information
 	 * @return the solar azimuth in degrees. Astronomical midday would be 180 in the norther hemosphere and 0 in the
 	 *            southern hemosphere. Depending on the location and time of year, sunrise will have an azimuth of about
 	 *            90&deg; and sunset about 270&deg;.
 	 */
-	public abstract double getSolarAzimuth(ZonedDateTime zonedDateTime, GeoLocation geoLocation);
+	public abstract double getSolarAzimuth(Calendar LocalDate localDate, GeoLocation geoLocation);
 
 	/**
 	 * Method to return the adjustment to the zenith required to account for the elevation. Since a person at a higher
@@ -270,25 +258,30 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * calculations are based on the level of available light at the given dip below the horizon, something that is not
 	 * affected by elevation, the adjustment should only be made if the zenith == 90&deg; {@link #adjustZenith adjusted}
 	 * for refraction and solar radius. The algorithm used is
-	 * 
+	 *
 	 * <pre>
 	 * elevationAdjustment = Math.toDegrees(Math.acos(earthRadiusInMeters / (earthRadiusInMeters + elevationMeters)));
 	 * </pre>
-	 * 
+	 *
 	 * The source of this algorithm is <a href="https://www.cs.tau.ac.il/~nachum/calendar-book/index.shtml">Calendrical
 	 * Calculations</a> by Edward M. Reingold and Nachum Dershowitz. An alternate algorithm that produces similar (but
 	 * not completely accurate) result found in Ma'aglay Tzedek by Moishe Kosower and other sources is:
-	 * 
+	 *
 	 * <pre>
 	 * elevationAdjustment = 0.0347 * Math.sqrt(elevationMeters);
 	 * </pre>
-	 * 
+	 *
 	 * @param elevation
 	 *            elevation in Meters.
+	 * @param latitude
+	 *            latitude in degrees (used to calculate geocentric radius)
 	 * @return the adjusted zenith
 	 */
-	double getElevationAdjustment(double elevation) {
-        return Math.toDegrees(Math.acos(earthRadius / (earthRadius + (elevation / 1000))));
+	double getElevationAdjustment(double elevation, double latitude) {
+		// Calculate geocentric radius at the observer's latitude using WGS84 ellipsoid
+		double geocentricRadius = getGeocentricRadius(latitude);
+		double elevationAdjustment = Math.toDegrees(Math.acos(geocentricRadius / (geocentricRadius + (elevation / 1000))));
+		return elevationAdjustment;
 	}
 
 	/**
@@ -310,7 +303,7 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 * for various <em>tzais</em> and <em>alos</em> times such as the
 	 * {@link com.kosherjava.zmanim.ZmanimCalendar#ZENITH_16_POINT_1 16.1&deg;} dip used in
 	 * {@link com.kosherjava.zmanim.ComprehensiveZmanimCalendar#getAlos16Point1Degrees()}.
-	 * 
+	 *
 	 * @param zenith
 	 *            the azimuth below the vertical zenith of 90&deg;. For sunset typically the {@link #adjustZenith
 	 *            zenith} used for the calculation uses geometric zenith of 90&deg; and {@link #adjustZenith adjusts}
@@ -319,15 +312,17 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 *            {@link com.kosherjava.zmanim.AstronomicalCalendar#NAUTICAL_ZENITH} to this method.
 	 * @param elevation
 	 *            elevation in Meters.
+	 * @param latitude
+	 *            latitude in degrees (used to calculate geocentric radius for elevation adjustment)
 	 * @return The zenith adjusted to include the {@link #getSolarRadius sun's radius}, {@link #getRefraction
-	 *         refraction} and {@link #getElevationAdjustment elevation} adjustment. This will only be adjusted for
+	 *         refraction} and {@link #getElevationAdjustment(double, double) elevation} adjustment. This will only be adjusted for
 	 *         sunrise and sunset (if the zenith == 90&deg;)
-	 * @see #getElevationAdjustment(double)
+	 * @see #getElevationAdjustment(double, double)
 	 */
-	double adjustZenith(double zenith, double elevation) {
+	double adjustZenith(double zenith, double elevation, double latitude) {
 		double adjustedZenith = zenith;
 		if (zenith == GEOMETRIC_ZENITH) { // only adjust if it is exactly sunrise or sunset
-			adjustedZenith = zenith + (getSolarRadius() + getRefraction() + getElevationAdjustment(elevation));
+			adjustedZenith = zenith + (getSolarRadius() + getRefraction() + getElevationAdjustment(elevation, latitude));
 		}
 		return adjustedZenith;
 	}
@@ -388,34 +383,6 @@ public abstract class AstronomicalCalculator implements Cloneable {
 	 */
 	public void setSolarRadius(double solarRadius) {
 		this.solarRadius = solarRadius;
-	}
-
-	/**
-	 * @see java.lang.Object#equals(Object)
-	 */
-	public boolean equals(Object object) {
-		if (this == object) {
-			return true;
-		}
-		if (object == null || getClass() != object.getClass()) {
-			return false;
-		}
-		AstronomicalCalculator calculator = (AstronomicalCalculator) object;
-		return Double.doubleToLongBits(getEarthRadius()) == Double.doubleToLongBits(calculator.getEarthRadius())
-				&& Double.doubleToLongBits(getRefraction()) == Double.doubleToLongBits(calculator.getRefraction())
-				&& Double.doubleToLongBits(getSolarRadius()) == Double.doubleToLongBits(calculator.getSolarRadius());
-	}
-
-	/**
-	 * @see java.lang.Object#hashCode()
-	 */
-	public int hashCode() {
-		int result = 17;
-		result = 37 * result + getClass().hashCode();
-		result = 37 * result + Double.hashCode(getEarthRadius());
-		result = 37 * result + Double.hashCode(getRefraction());
-		result = 37 * result + Double.hashCode(getSolarRadius());
-		return result;
 	}
 
 	/**

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -1,6 +1,6 @@
 /*
  * Zmanim Java API
- * Copyright (C) 2004-2025 Eliyahu Hershfeld
+ * Copyright (C) 2004-2026 Eliyahu Hershfeld
  *
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
  * Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option)

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -1,6 +1,6 @@
 /*
  * Zmanim Java API
- * Copyright (C) 2004-2026 Eliyahu Hershfeld
+ * Copyright (C) 2004-2025 Eliyahu Hershfeld
  *
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
  * Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option)
@@ -15,9 +15,7 @@
  */
 package com.kosherjava.zmanim.util;
 
-import java.time.ZoneOffset;
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;\nimport java.time.ZonedDateTime;
 
 /**
  * Implementation of sunrise and sunset methods to calculate astronomical times based on the <a
@@ -30,7 +28,7 @@ import java.time.ZonedDateTime;
  * to account for elevation. The algorithm can be found in the <a
  * href="https://en.wikipedia.org/wiki/Sunrise_equation">Wikipedia Sunrise Equation</a> article.
  * 
- * @author &copy; Eliyahu Hershfeld 2011 - 2026
+ * @author &copy; Eliyahu Hershfeld 2011 - 2025
  */
 public class NOAACalculator extends AstronomicalCalculator {
 	
@@ -70,73 +68,48 @@ public class NOAACalculator extends AstronomicalCalculator {
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(LocalDate, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunrise(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
-		return getUTCSunRiseSet(dt, geoLocation, zenith, adjustForElevation,SolarEvent.SUNRISE);
+	public double getUTCSunrise(LocalDate localDate, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
+		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
+		double adjustedZenith = adjustZenith(zenith, elevation, geoLocation.getLatitude());
+		double sunrise = getSunRiseSetUTC(calendar, geoLocation.getLatitude(), -geoLocation.getLongitude(),
+				adjustedZenith, SolarEvent.SUNRISE);
+		sunrise = sunrise / 60;
+		return sunrise > 0  ? sunrise % 24 : sunrise % 24 + 24; // ensure that the time is >= 0 and < 24
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(LocalDate, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunset(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
-		return getUTCSunRiseSet(dt, geoLocation, zenith, adjustForElevation,SolarEvent.SUNSET);
-	}
-	
-	/**
-	 * A method that calculates UTC sunrise or sunset as well as any time based on an angle above or below sunset and
-	 * returns it as a <code>double</code> in 24-hour format. 5:45:00 AM will return 5.75.
-	 * 
-	 * @param localDate
-	 *            Used to calculate day of year.
-	 * @param geoLocation
-	 *            The location information used for astronomical calculating sun times.
-	 * @param zenith
-	 *            the azimuth below the vertical zenith of 90&deg;. For sunset typically the {@link #adjustZenith
-	 *            zenith} used for the calculation uses geometric zenith of 90&deg; and {@link #adjustZenith adjusts}
-	 *            this slightly to account for solar refraction and the sun's radius. Another example would be
-	 *            {@link com.kosherjava.zmanim.AstronomicalCalendar#getEndNauticalTwilight()} that passes
-	 *            {@link com.kosherjava.zmanim.AstronomicalCalendar#NAUTICAL_ZENITH} to this method.
-	 * @param adjustForElevation
-	 *            Should the time be adjusted for elevation
-	 * @param solarEvent if the calculation is for {@link SolarEvent#SUNRISE} or {@link SolarEvent#SUNSET}
-	 * @return The UTC time of sunset in 24-hour format. 5:45:00 AM will return 5.75. If an error was encountered in
-	 *         the calculation (expected behavior for some locations such as near the poles,
-	 *         {@link java.lang.Double#NaN} will be returned.
-	 * @see #getElevationAdjustment(double)
-	 */
-	private double getUTCSunRiseSet(LocalDate localDate, GeoLocation geoLocation, double zenith, boolean adjustForElevation, 
-			SolarEvent solarEvent) {
+	public double getUTCSunset(LocalDate localDate, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
-		double adjustedZenith = adjustZenith(zenith, elevation);
-		double riseSet = getSunRiseSetUTC(localDate, geoLocation.getLatitude(), -geoLocation.getLongitude(),
-				adjustedZenith, solarEvent);
-		riseSet = riseSet / 60;
-		return riseSet > 0  ? riseSet % 24 : riseSet % 24 + 24; // ensure that the time is >= 0 and < 24
+		double adjustedZenith = adjustZenith(zenith, elevation, geoLocation.getLatitude());
+		double sunset = getSunRiseSetUTC(calendar, geoLocation.getLatitude(), -geoLocation.getLongitude(),
+				adjustedZenith, SolarEvent.SUNSET);
+		sunset = sunset / 60;
+		return sunset > 0  ? sunset % 24 : sunset % 24 + 24; // ensure that the time is >= 0 and < 24
 	}
 
 	/**
 	 * Return the <a href="https://en.wikipedia.org/wiki/Julian_day">Julian day</a> from a Java Calendar.
 	 * 
-	 * @param localDate
-	 *            The LocalDate
+	 * @param calendar
+	 *            The Java Calendar
 	 * @return the Julian day corresponding to the date Note: Number is returned for the start of the Julian
 	 *         day. Fractional days / time should be added later.
 	 */
 	private static double getJulianDay(LocalDate localDate) {
-	    int year = localDate.getYear();
-	    int month = localDate.getMonthValue();
-	    int day = localDate.getDayOfMonth();
-
-	    if (month <= 2) {
-	        year -= 1;
-	        month += 12;
-	    }
-
-	    int a = year / 100;
-	    int b = 2 - a + a / 4;
-
-	    return Math.floor(365.25 * (year + 4716)) + Math.floor(30.6001 * (month + 1)) + day + b - 1524.5;
+		int year = calendar.get(Calendar.YEAR);
+		int month = calendar.get(Calendar.MONTH) + 1;
+		int day = calendar.get(Calendar.DAY_OF_MONTH);
+		if (month <= 2) {
+			year -= 1;
+			month += 12;
+		}
+		int a = year / 100;
+		int b = 2 - a + a / 4;
+		return Math.floor(365.25 * (year + 4716)) + Math.floor(30.6001 * (month + 1)) + day + b - 1524.5;
 	}
 
 	/**
@@ -231,7 +204,8 @@ public class NOAACalculator extends AstronomicalCalculator {
 	private static double getSunApparentLongitude(double julianCenturies) {
 		double sunTrueLongitude = getSunTrueLongitude(julianCenturies);
 		double omega = 125.04 - 1934.136 * julianCenturies;
-        return sunTrueLongitude - 0.00569 - 0.00478 * Math.sin(Math.toRadians(omega));
+		double lambda = sunTrueLongitude - 0.00569 - 0.00478 * Math.sin(Math.toRadians(omega));
+		return lambda;
 	}
 
 	/**
@@ -276,7 +250,8 @@ public class NOAACalculator extends AstronomicalCalculator {
 		double obliquityCorrection = getObliquityCorrection(julianCenturies);
 		double lambda = getSunApparentLongitude(julianCenturies);
 		double sint = Math.sin(Math.toRadians(obliquityCorrection)) * Math.sin(Math.toRadians(lambda));
-        return Math.toDegrees(Math.asin(sint));
+		double theta = Math.toDegrees(Math.asin(sint));
+		return theta;
 	}
 
 	/**
@@ -332,18 +307,18 @@ public class NOAACalculator extends AstronomicalCalculator {
 	}
 	
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(ZonedDateTime, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(Calendar, GeoLocation)
 	 */
-	public double getSolarElevation(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
-		return getSolarElevationAzimuth(zonedDateTime, geoLocation, false);
+	public double getSolarElevation(LocalDate localDate, GeoLocation geoLocation) {
+		return getSolarElevationAzimuth(calendar, geoLocation, false);
 
 	}
-
+	
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(ZonedDateTime, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(Calendar, GeoLocation)
 	 */
-	public double getSolarAzimuth(ZonedDateTime zonedDateTime, GeoLocation geoLocation) {
-		return getSolarElevationAzimuth(zonedDateTime, geoLocation, true);
+	public double getSolarAzimuth(LocalDate localDate, GeoLocation geoLocation) {
+		return getSolarElevationAzimuth(calendar, geoLocation, true);
 	}
 
 	/**
@@ -352,7 +327,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * and time. Can be negative if the sun is below the horizon. Elevation is based on sea-level and is not
 	 * adjusted for altitude.
 	 * 
-	 * @param zonedDateTime
+	 * @param calendar
 	 *            time of calculation
 	 * @param geoLocation
 	 *            The location for calculating the elevation or azimuth.
@@ -360,53 +335,62 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 *            true for azimuth, false for elevation
 	 * @return solar elevation or azimuth in degrees.
 	 * 
-	 * @see #getSolarElevation(ZonedDateTime, GeoLocation)
-	 * @see #getSolarAzimuth(ZonedDateTime, GeoLocation)
+	 * @see #getSolarElevation(Calendar, GeoLocation)
+	 * @see #getSolarAzimuth(Calendar, GeoLocation)
 	 */
-	private double getSolarElevationAzimuth(ZonedDateTime zonedDateTime, GeoLocation geoLocation, boolean isAzimuth) {
-
-	    double lat = Math.toRadians(geoLocation.getLatitude());
-	    double lon = geoLocation.getLongitude();
-
-        ZonedDateTime utc = zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
-
-	    double fractionalDay =
-	            (utc.getHour()
-	            + (utc.getMinute()
-	            + (utc.getSecond() + utc.getNano() / 1_000_000_000.0) / 60.0) / 60.0) / 24.0;
-
-	    double jd = getJulianDay(utc.toLocalDate()) + fractionalDay;
-	    double jc = getJulianCenturiesFromJulianDay(jd);
-
-	    double decl = Math.toRadians(getSunDeclination(jc));
-	    double eot = getEquationOfTime(jc);
-
-	    double trueSolarTime = ((fractionalDay + eot / 1440.0 + lon / 360.0) + 2) % 1;
-	    double hourAngle = trueSolarTime * 2 * Math.PI - Math.PI;
-
-	    double cosZenith =
-	            Math.sin(lat) * Math.sin(decl)
-	            + Math.cos(lat) * Math.cos(decl) * Math.cos(hourAngle);
-
-	    double zenith = Math.acos(Math.max(-1, Math.min(1, cosZenith)));
-	    double elevation = 90 - Math.toDegrees(zenith);
-
-	    double azimuth;
-	    double azDenom = Math.cos(lat) * Math.sin(zenith);
-
-	    if (Math.abs(azDenom) > 0.001) {
-	        double az =
-	                (Math.sin(lat) * Math.cos(zenith) - Math.sin(decl)) / azDenom;
-
-	        azimuth = 180 - Math.toDegrees(Math.acos(Math.max(-1, Math.min(1, az))))
-	                * (hourAngle > 0 ? -1 : 1);
-	    } else {
-	        azimuth = geoLocation.getLatitude() > 0 ? 180 : 0;
-	    }
-
-	    return isAzimuth ? (azimuth + 360) % 360 : elevation;
+	private double getSolarElevationAzimuth(LocalDate localDate, GeoLocation geoLocation, boolean isAzimuth) {
+		double latitude = geoLocation.getLatitude();
+		double longitude = geoLocation.getLongitude();
+		
+		Calendar cloned = (Calendar) calendar.clone();
+		int offset = - adjustHourForTimeZone(cloned);
+		cloned.add(Calendar.MILLISECOND, offset);
+		int minute = cloned.get(Calendar.MINUTE);
+		int second = cloned.get(Calendar.SECOND);
+		int hour = cloned.get(Calendar.HOUR_OF_DAY);
+		int milli = cloned.get(Calendar.MILLISECOND);
+		
+		double time = (hour + (minute + (second + (milli / 1000.0)) / 60.0) / 60.0 ) / 24.0;
+		double julianDay = getJulianDay(cloned) + time;
+		double julianCenturies = getJulianCenturiesFromJulianDay(julianDay);
+		double eot = getEquationOfTime(julianCenturies);
+		double theta = getSunDeclination(julianCenturies);
+		
+		double adjustment = time + eot / 1440;
+		double trueSolarTime = ((adjustment + longitude / 360) + 2) % 1; // adding 2 to ensure that it never ends up negative
+		double hourAngelRad = trueSolarTime * Math.PI * 2 - Math.PI;
+		double cosZenith = Math.sin(Math.toRadians(latitude)) * Math.sin(Math.toRadians(theta))
+				+  Math.cos(Math.toRadians(latitude)) * Math.cos(Math.toRadians(theta)) * Math.cos(hourAngelRad);
+		double zenith = Math.toDegrees(Math.acos(cosZenith > 1 ? 1 : cosZenith < -1 ? -1 : cosZenith));
+		double azDenom = Math.cos(Math.toRadians(latitude)) * Math.sin(Math.toRadians(zenith));
+		double refractionAdjustment = 0;
+		double elevation = 90.0 - (zenith - refractionAdjustment);
+		double azimuth = 0;
+		double azRad = (Math.sin(Math.toRadians(latitude)) * Math.cos(Math.toRadians(zenith))
+				- Math.sin(Math.toRadians(theta))) / azDenom;
+		if(Math.abs(azDenom) > 0.001) {
+			azimuth = 180 - Math.toDegrees(Math.acos(azRad > 1 ? 1 : azRad < -1? -1 : azRad)) * (hourAngelRad > 0 ? -1 : 1) ;
+		} else {
+			azimuth = latitude > 0 ? 180 : 0;
+		}
+		return isAzimuth ? azimuth % 360 : elevation;
 	}
 	
+	/**
+	 * Returns the hour of day adjusted for the timezone and DST. This is needed for the azimuth and elevation
+	 * calculations.
+	 * @param calendar the Calendar to extract the hour from. This must have the timezone set to the proper timezone.
+	 * @return the adjusted hour corrected for timezone and DST offset.
+	 */
+	private int adjustHourForTimeZone(LocalDate localDate) {
+		int offset = calendar.getTimeZone().getRawOffset();
+		int dstOffset = calendar.getTimeZone().getDSTSavings();
+		if(calendar.getTimeZone().inDaylightTime(calendar.getTime())) {
+			offset = offset + dstOffset;
+		}
+		return offset;
+	}
+
 	/**
 	 * Return the <a href="https://en.wikipedia.org/wiki/Universal_Coordinated_Time">Universal Coordinated Time</a> (UTC)
 	 * of <a href="https://en.wikipedia.org/wiki/Noon#Solar_noon">solar noon</a> for the given day at the given location
@@ -414,18 +398,18 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * Other calculators may return a more simplified calculation of halfway between sunrise and sunset. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of <em>Chatzos</em></a> for details on
 	 * solar noon calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see #getSolarNoonMidnightUTC(double, double, SolarEvent)
 	 * 
-	 * @param localDate
-	 *            The localDate representing the date to calculate solar noon for
+	 * @param calendar
+	 *            The Calendar representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times. This class uses only requires
 	 *            the longitude for calculating noon since it is the same time anywhere along the longitude line.
 	 * @return the time in minutes from zero UTC
 	 */
 	public double getUTCNoon(LocalDate localDate, GeoLocation geoLocation) {
-		double noon = getSolarNoonMidnightUTC(getJulianDay(localDate), -geoLocation.getLongitude(), SolarEvent.NOON);
+		double noon = getSolarNoonMidnightUTC(getJulianDay(calendar), -geoLocation.getLongitude(), SolarEvent.NOON);
 		noon = noon / 60;
 		return noon > 0  ? noon % 24 : noon % 24 + 24; // ensure that the time is >= 0 and < 24
 	}
@@ -438,18 +422,18 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * simplified calculation of halfway between sunrise and sunset. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of <em>Chatzos</em></a> for details on
 	 * solar noon / midnight calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see #getSolarNoonMidnightUTC(double, double, SolarEvent)
 	 * 
-	 * @param localDate
-	 *            The <code>LocalDate</code> representing the date to calculate solar noon for
+	 * @param calendar
+	 *            The Calendar representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times. This class uses only requires
 	 *            the longitude for calculating noon since it is the same time anywhere along the longitude line.
 	 * @return the time in minutes from zero UTC
 	 */
 	public double getUTCMidnight(LocalDate localDate, GeoLocation geoLocation) {
-		double midnight = getSolarNoonMidnightUTC(getJulianDay(localDate), -geoLocation.getLongitude(), SolarEvent.MIDNIGHT);
+		double midnight = getSolarNoonMidnightUTC(getJulianDay(calendar), -geoLocation.getLongitude(), SolarEvent.MIDNIGHT);
 		midnight = midnight / 60;
 		return midnight > 0  ? midnight % 24 : midnight % 24 + 24; // ensure that the time is >= 0 and < 24
 	}
@@ -469,8 +453,8 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 *            
 	 * @return the time in minutes from zero UTC
 	 * 
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
-	 * @see #getUTCNoon(LocalDate, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
+	 * @see #getUTCNoon(Calendar, GeoLocation)
 	 */
 	private static double getSolarNoonMidnightUTC(double julianDay, double longitude, SolarEvent solarEvent) {
 		julianDay = (solarEvent == SolarEvent.NOON) ? julianDay : julianDay + 0.5;
@@ -490,8 +474,8 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 * of sunrise or sunset in minutes for the given day at the given location on earth.
 	 * @todo Possibly increase the number of passes for improved accuracy, especially in the Arctic areas.
 	 * 
-	 * @param localDate
-	 *            The <code>LocalDate</code>.
+	 * @param calendar
+	 *            The calendar
 	 * @param latitude
 	 *            The latitude of observer in degrees
 	 * @param longitude
@@ -504,7 +488,7 @@ public class NOAACalculator extends AstronomicalCalculator {
 	 */
 	private static double getSunRiseSetUTC(LocalDate localDate, double latitude, double longitude, double zenith,
 			SolarEvent solarEvent) {
-		double julianDay = getJulianDay(localDate);
+		double julianDay = getJulianDay(calendar);
 
 		// Find the time of solar noon at the location, and use that declination.
 		// This is better than start of the Julian day

--- a/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
@@ -1,6 +1,6 @@
 /*
  * Zmanim Java API
- * Copyright (C) 2004-2025 Eliyahu Hershfeld
+ * Copyright (C) 2004-2026 Eliyahu Hershfeld
  *
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
  * Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option)

--- a/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/SunTimesCalculator.java
@@ -1,6 +1,6 @@
 /*
  * Zmanim Java API
- * Copyright (C) 2004-2026 Eliyahu Hershfeld
+ * Copyright (C) 2004-2025 Eliyahu Hershfeld
  *
  * This library is free software; you can redistribute it and/or modify it under the terms of the GNU Lesser General
  * Public License as published by the Free Software Foundation; either version 2.1 of the License, or (at your option)
@@ -15,8 +15,7 @@
  */
 package com.kosherjava.zmanim.util;
 
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;\nimport java.time.ZonedDateTime;
 
 /**
  * Implementation of sunrise and sunset methods to calculate astronomical times. This calculator uses the Java algorithm
@@ -27,7 +26,7 @@ import java.time.ZonedDateTime;
  * account for leap years. It is not as accurate as the Jean Meeus based {@link NOAACalculator} that is the default calculator
  * use by the KosherJava <em>zmanim</em> library.
  *
- * @author &copy; Eliyahu Hershfeld 2004 - 2026
+ * @author &copy; Eliyahu Hershfeld 2004 - 2025
  * @author &copy; Kevin Boone 2000
  */
 public class SunTimesCalculator extends AstronomicalCalculator {
@@ -47,21 +46,21 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(LocalDate, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunrise(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunrise(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
+	public double getUTCSunrise(LocalDate localDate, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
-		double adjustedZenith = adjustZenith(zenith, elevation);
-		return getTimeUTC(dt, geoLocation, adjustedZenith, true);
+		double adjustedZenith = adjustZenith(zenith, elevation, geoLocation.getLatitude());
+		return getTimeUTC(calendar, geoLocation, adjustedZenith, true);
 	}
 
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(LocalDate, GeoLocation, double, boolean)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCSunset(Calendar, GeoLocation, double, boolean)
 	 */
-	public double getUTCSunset(LocalDate dt, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
+	public double getUTCSunset(LocalDate localDate, GeoLocation geoLocation, double zenith, boolean adjustForElevation) {
 		double elevation = adjustForElevation ? geoLocation.getElevation() : 0;
-		double adjustedZenith = adjustZenith(zenith, elevation);
-		return getTimeUTC(dt, geoLocation, adjustedZenith, false);
+		double adjustedZenith = adjustZenith(zenith, elevation, geoLocation.getLatitude());
+		return getTimeUTC(calendar, geoLocation, adjustedZenith, false);
 	}
 
 	/**
@@ -223,8 +222,8 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * Get sunrise or sunset time in UTC, according to flag. This time is returned as
 	 * a double and is not adjusted for time-zone.
 	 * 
-	 * @param localDate
-	 *            the <code>LocalDate</code> object to extract the day of year for calculation
+	 * @param calendar
+	 *            the Calendar object to extract the day of year for calculation
 	 * @param geoLocation
 	 *            the GeoLocation object that contains the latitude and longitude
 	 * @param zenith
@@ -236,7 +235,7 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 *         {@link Double#NaN} will be returned.
 	 */
 	private static double getTimeUTC(LocalDate localDate, GeoLocation geoLocation, double zenith, boolean isSunrise) {
-		int dayOfYear = localDate.getDayOfYear();
+		int dayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
 		double sunMeanAnomaly = getMeanAnomaly(dayOfYear, geoLocation.getLongitude(), isSunrise);
 		double sunTrueLong = getSunTrueLongitude(sunMeanAnomaly);
 		double sunRightAscensionHours = getSunRightAscensionHours(sunTrueLong);
@@ -263,19 +262,19 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * {@link NOAACalculator}, the default calculator, returns true solar noon. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of Chatzos</a> for details on solar
 	 * noon calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see NOAACalculator
 	 * 
-	 * @param localDate
-	 *            The <code>LocalDate</code> representing the date to calculate solar noon for
+	 * @param calendar
+	 *            The Calendar representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
 	 * @return the time in minutes from zero UTC. If an error was encountered in the calculation (expected behavior for
 	 *         some locations such as near the poles, {@link Double#NaN} will be returned.
 	 */
 	public double getUTCNoon(LocalDate localDate, GeoLocation geoLocation) {
-		double sunrise = getUTCSunrise(localDate, geoLocation, 90, false);
-		double sunset = getUTCSunset(localDate, geoLocation, 90, false);
+		double sunrise = getUTCSunrise(calendar, geoLocation, 90, false);
+		double sunset = getUTCSunset(calendar, geoLocation, 90, false);
 		double noon = sunrise + ((sunset - sunrise) / 2);
 		if (noon < 0) {
 			noon += 12;
@@ -293,31 +292,31 @@ public class SunTimesCalculator extends AstronomicalCalculator {
 	 * {@link NOAACalculator}, the default calculator, returns true solar noon. See <a href=
 	 * "https://kosherjava.com/2020/07/02/definition-of-chatzos/">The Definition of Chatzos</a> for details on solar
 	 * noon calculations.
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(LocalDate, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getUTCNoon(Calendar, GeoLocation)
 	 * @see NOAACalculator
 	 * 
-	 * @param localDate
-	 *            The <code>LocalDate</code> representing the date to calculate solar noon for
+	 * @param calendar
+	 *            The Calendar representing the date to calculate solar noon for
 	 * @param geoLocation
 	 *            The location information used for astronomical calculating sun times.
 	 * @return the time in minutes from zero UTC. If an error was encountered in the calculation (expected behavior for
 	 *         some locations such as near the poles, {@link Double#NaN} will be returned.
 	 */
 	public double getUTCMidnight(LocalDate localDate, GeoLocation geoLocation) {
-		return (getUTCNoon(localDate, geoLocation) + 12);
+		return (getUTCNoon(calendar, geoLocation) + 12);
 	}
 	
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(ZonedDateTime, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarAzimuth(Calendar, GeoLocation)
 	 */
-	public double getSolarAzimuth(ZonedDateTime zdt, GeoLocation geoLocation) {
+	public double getSolarAzimuth(LocalDate localDate, GeoLocation geoLocation) {
 		throw new UnsupportedOperationException("The SunTimesCalculator class does not implement the getSolarAzimuth method. Use the NOAACalculator instead.");
 	}
 	
 	/**
-	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(ZonedDateTime, GeoLocation)
+	 * @see com.kosherjava.zmanim.util.AstronomicalCalculator#getSolarElevation(Calendar, GeoLocation)
 	 */
-	public double getSolarElevation(ZonedDateTime zdt, GeoLocation geoLocation) {
+	public double getSolarElevation(LocalDate localDate, GeoLocation geoLocation) {
 		throw new UnsupportedOperationException("The SunTimesCalculator class does not implement the getSolarElevation method. Use the NOAACalculator instead.");
 	}
 }


### PR DESCRIPTION
Use WGS84 ellipsoid for latitude-dependent Earth radius in elevation adjustments

Add getGeocentricRadius() to AstronomicalCalculator that calculates
Earth's radius based on observer latitude using WGS84 ellipsoid.
ZmanimCalendar now uses this when elevation adjustments are enabled.

Earth's radius varies from 6378.137 km at equator to 6356.752 km at
poles. Using a fixed 6356.9 km introduced systematic errors of ~14 km
at mid-latitudes. This change provides latitude-dependent accuracy using the WGS84 ellipsoid.

Reference: WGS84 ellipsoid parameters (NGA Technical Report 8350.2)