### PR TITLE
Some bug fixes

### DIFF
--- a/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
+++ b/src/main/java/com/kosherjava/zmanim/AstronomicalCalendar.java
@@ -721,8 +721,9 @@ public class AstronomicalCalendar implements Cloneable {
 	 * @see GeoLocation#getLocalMeanTimeOffset(Instant)
 	 */
 	public Instant getLocalMeanTime(LocalTime localTime) {
-	    Instant civilTime = ZonedDateTime.of(getAdjustedLocalDate(), localTime, getGeoLocation().getZoneId()).toInstant();
-	    return getTimeOffset(civilTime, -getGeoLocation().getLocalMeanTimeOffset(civilTime));
+	    Instant localMeanTime = LocalDateTime.of(getAdjustedLocalDate(), localTime).toInstant(ZoneOffset.UTC);
+	    long longitudeOffsetMillis = (long) (getGeoLocation().getLongitude() * 4 * MINUTE_MILLIS);
+	    return getTimeOffset(localMeanTime, -longitudeOffsetMillis);
 	}
 
 	/**

--- a/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
+++ b/src/main/java/com/kosherjava/zmanim/hebrewcalendar/JewishDate.java
@@ -1093,8 +1093,9 @@ public class JewishDate implements Comparable<JewishDate>, Cloneable {
             if (month == TISHREI) {
                 month = ELUL;
                 year--;
-            } else if ((! isJewishLeapYear(year) && month == ADAR)
-                    || (isJewishLeapYear(year) && month == ADAR_II)){
+            } else if (month == NISSAN) {
+                month = getLastMonthOfJewishYear(year);
+            } else if (!isJewishLeapYear(year) && month == ADAR){
                 month = SHEVAT;
             } else {
                 month--;

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -480,8 +480,9 @@ public class NOAACalculator extends AstronomicalCalculator {
 		double solNoonUTC = (longitude * 4) - equationOfTime; // minutes
 
 		// Refine the equation of time at the calculated transit time.
+		double newt;
 		for (int i = 0; i < 2; i++) {
-			double newt = getJulianCenturiesFromJulianDay(julianDay + solNoonUTC / 1440.0);
+			newt = getJulianCenturiesFromJulianDay(julianDay + solNoonUTC / 1440.0);
 			equationOfTime = getEquationOfTime(newt);
 			solNoonUTC = (solarEvent == SolarEvent.NOON ? 720 : 1440) + (longitude * 4) - equationOfTime;
 		}

--- a/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
+++ b/src/main/java/com/kosherjava/zmanim/util/NOAACalculator.java
@@ -478,11 +478,14 @@ public class NOAACalculator extends AstronomicalCalculator {
 		double tnoon = getJulianCenturiesFromJulianDay(julianDay + longitude / 360.0);
 		double equationOfTime = getEquationOfTime(tnoon);
 		double solNoonUTC = (longitude * 4) - equationOfTime; // minutes
-		
-		// second pass
-		double newt = getJulianCenturiesFromJulianDay(julianDay + solNoonUTC / 1440.0);
-		equationOfTime = getEquationOfTime(newt);
-		return (solarEvent == SolarEvent.NOON ? 720 : 1440) + (longitude * 4) - equationOfTime;
+
+		// Refine the equation of time at the calculated transit time.
+		for (int i = 0; i < 2; i++) {
+			double newt = getJulianCenturiesFromJulianDay(julianDay + solNoonUTC / 1440.0);
+			equationOfTime = getEquationOfTime(newt);
+			solNoonUTC = (solarEvent == SolarEvent.NOON ? 720 : 1440) + (longitude * 4) - equationOfTime;
+		}
+		return (solarEvent == SolarEvent.NOON ? 720 : 1440) + (longitude * 4 ) - equationOfTime;
 	}
 	
 	/**


### PR DESCRIPTION
1. `Africa/Khartoum` that had a transition from 11:59:59 to 13:00:00 on Jan 15, 2000. Previously, we would return the incorrect time because we were creating a ZonedDateTime for 12:00 and then adding n hours to it. However, THERE IS NO 12:00 on Jan 15, 2000. Java automatically bumps the ZonedDateTime to 13:00. Chatzos is returned an hour later than it should.

<details><summary>Failing Test Case</summary>
<p>

```rust
TestCase {
        year: 2000,
        month: 1,
        day: 15,
        latitude: 21.743167270756928,
        longitude: 27.55334330024661,
        elevation: 486.715389268106,
        timezone: "Africa/Khartoum",
        preset_name: "getFixedLocalChatzos",
        ateret_torah_sunset_offset_minutes: 23,
        candle_lighting_offset_minutes: 36,
        use_astronomical_chatzos_for_other_zmanim: false,
        use_elevation: false,
}
``` 

</p>
</details> 

2. Previously, going back a single month from AdarII would skip AdarI and go directly to Sivan.
3. Added a single iteration to improve noon accuracy